### PR TITLE
Completed the following test cases:

### DIFF
--- a/web/lib/admin.py
+++ b/web/lib/admin.py
@@ -53,6 +53,7 @@ class Admin(Base):
     ADMIN_CUSTOM_DATA_PROFILE_ID_OPTION             = ('xpath', '//option[@value="PROFILE_ID"]')
     ADMIN_SECURE_EMBED                              = ('id', 'secureEmbed')
     ADMIN_AUTO_PLAY_ON_LOAD                         = ('id', 'autoPlayOnLoad')
+    ADMIN_ALLOW_ANONYMOUS                           = ('id', 'allowAnonymous')
     ADMIN_ASSIGNMENT_SUBMISSION                     = ('xpath', '//select[@id="enableAssignmentSubmission"]')
     ADMIN_GALLERY_PAGE_SIZE                         = ('xpath', "//input[@id='pageSize']")
     ADMIN_ADD_ALLOWEDUSERS                          = ('xpath', "//a[@class='add' and contains(text(),'+ Add \"allowedUsers\"')]")
@@ -1133,4 +1134,34 @@ class Admin(Base):
             return False
             
         writeToLog("INFO","Success, Auto Play On load was set to: " + str(selection) + "'")
+        return True
+    
+    
+    # @Author: Horia Cus
+    # This function can enable or disable auto play on player
+    # if isEnabled = True, allow anonymous will be enabled
+    # if isEnabled = False, allow anonymous will be disabled
+    def allowAnonymous(self, isEnabled):
+        #Login to Admin
+        if self.loginToAdminPage() == False:
+            writeToLog("INFO","FAILED to login to admin page")
+            return False
+        
+        #Navigate to Authentication module
+        if self.navigate(localSettings.LOCAL_SETTINGS_KMS_ADMIN_URL + '/config/tab/auth') == False:
+            writeToLog("INFO","FAILED to load Authentication Page in admin")
+            return False
+        sleep(1) 
+        
+        #Enable/Disable anonymous user option
+        selection = self.convertBooleanToYesNo(isEnabled)
+        if self.select_from_combo_by_text(self.ADMIN_ALLOW_ANONYMOUS, selection) == False:
+            writeToLog("INFO","FAILED to set allow anonymous as: " + str(selection))
+            return False
+         
+        if self.adminSave() == False:
+            writeToLog("INFO","FAILED to save changes the changes in admin page")
+            return False
+            
+        writeToLog("INFO","Success, Allow Anonymous was set to: " + str(selection) + "'")
         return True  

--- a/web/lib/channel.py
+++ b/web/lib/channel.py
@@ -356,6 +356,10 @@ class Channel(Base):
             writeToLog("INFO","FAILED to navigate to Channels")
             return False
         
+        if self.wait_element(self.clsCommon.login.LOGIN_SIGN_IN_BTN, 1, True) != False:
+            writeToLog("INFO", "FAILED, authentication page is presented in Channels")
+            return False
+        
         return True
        
        
@@ -1124,8 +1128,8 @@ class Channel(Base):
 
     
     #  @Author: Oded berihon
-    def navigateToEntryFromChannel(self, channelName, entryName): 
-        if self.navigateToChannel(channelName) == False:
+    def navigateToEntryFromChannel(self, channelName, entryName, navigateFrom=enums.Location.MY_CHANNELS_PAGE): 
+        if self.navigateToChannel(channelName, navigateFrom) == False:
             writeToLog("INFO","FAILED to navigate to Channel page")
             return False
         

--- a/web/lib/editEntryPage.py
+++ b/web/lib/editEntryPage.py
@@ -1685,6 +1685,6 @@ class EditEntryPage(Base):
         if self.wait_element(userRow, 2, True) != False:
             writeToLog("INFO", "FAILED, the table for " + userID + " is still presented after removing the user")
             return False
-        
+        sleep(1)
         writeToLog("INFO", "The " + userID + " has been successfully removed from the Collaboration list")
         return True

--- a/web/lib/login.py
+++ b/web/lib/login.py
@@ -63,8 +63,9 @@ class Login(Base):
             if verifyUrl == True:
                 self.clsCommon.myMedia.verifyUrl(url, False)
            
-        
-    def logOutOfKMS(self):
+    
+    # If allowAnonymous=False, we will no longer verify if the user is guest because the authentication screen is presented
+    def logOutOfKMS(self, allowAnonymous=True):
         # Click on the user menu button
         if self.click(self.USER_MENU_TOGGLE_BTN) == False:
             writeToLog("INFO","FAILED to click on user menu button")
@@ -77,10 +78,11 @@ class Login(Base):
             return False
         
         sleep(2)
-        # Verify user now is guest
-        if self.wait_visible(self.USER_GUEST, 5) == False:
-            writeToLog("INFO","FAILED verify user was logout")
-            return False
+        if allowAnonymous == True:
+            # Verify user now is guest
+            if self.wait_visible(self.USER_GUEST, 5) == False:
+                writeToLog("INFO","FAILED verify user was logout")
+                return False
         
         writeToLog("INFO","Success user was logout")   
         return True
@@ -162,3 +164,17 @@ class Login(Base):
             writeToLog("INFO","FAILED to login as '" + username + "@" + password + "'")
             self.takeScreeshotGeneric("FAIL_LOGIN_TO_KMS")
             raise Exception(inst)
+        
+        
+    def logOutThenLogInToKMS(self,username, password, url='', allowAnonymous=True):
+        # Log Out from the account
+        if self.logOutOfKMS(allowAnonymous) == False:
+            writeToLog("INFO","FAILED to log out from the current KMS account")  
+            return False
+        
+        # Log In with the desired KMS account
+        if self.loginToKMS(username, password, url) == False:
+            writeToLog("INFO", "FAILED to authenticate to the " + username + " KMS account " )
+            return False
+        
+        return True

--- a/web/lib/player.py
+++ b/web/lib/player.py
@@ -882,7 +882,7 @@ class Player(Base):
                 
                 if quizEntry == True:
                     # Verify if the Question Screen is displayed
-                    if self.wait_element(self.PLAYER_QUIZ_SKIP_FOR_NOW_BUTTON, 0.3, True) != False:
+                    if self.wait_element(self.PLAYER_QUIZ_SKIP_FOR_NOW_BUTTON, 0.5, True) != False:
                         sleep(1)
                         # Resume the playing process by skipping the Question Screen
                         if self.click(self.PLAYER_QUIZ_SKIP_FOR_NOW_BUTTON, 1, True) == False:

--- a/web/tests/entitlements/test_4984.py
+++ b/web/tests/entitlements/test_4984.py
@@ -135,7 +135,7 @@ class Test:
                 return
             
             writeToLog("INFO","Step 14: Going to authenticate using " + self.coEditorUser)
-            if self.common.login.loginToKMS(self.coEditorUser, self.coPublisherPass) == False:
+            if self.common.login.loginToKMS(self.coEditorUser, self.coEditorPass) == False:
                 writeToLog("INFO","Step 14: FAILED to authenticate using " + self.coEditorUser)
                 return
             

--- a/web/tests/entitlements/test_4999.py
+++ b/web/tests/entitlements/test_4999.py
@@ -1,0 +1,197 @@
+import time, pytest
+import sys,os
+sys.path.insert(1,os.path.abspath(os.path.join(os.path.dirname( __file__ ),'..','..','lib')))
+from clsCommon import Common
+import clsTestService
+from localSettings import *
+import localSettings
+from utilityTestFunc import *
+import enums
+import collections
+
+
+class Test:
+
+    #================================================================================================================================
+    #  @Author: Horia Cus
+    # Test Name : Entitlements - Private Channel using Channels Page 
+    # Test description:
+    # 1. Create a Private Channel
+    # 2. Publish an entry inside the Private Channel
+    # 3. Add a member and a contributor to the private channel
+    # 4. Verify that the Channel owner has full control over the private channel
+    # 5. Verify that the Anonymous user and KMS User is able to access only the Channels page and that the Private Channel is not displayed
+    # 6. Verify that the Channel Member is able to navigate to the Private Channel using Channels page but its not able to access 'Add to Channel' tab
+    # 7. Verify that the Contributor Member is able to navigate to the Private Channel using Channels page and its not able to access 'Add to Channel' tab
+    #================================================================================================================================
+    testNum = "4999"
+
+    supported_platforms = clsTestService.updatePlatforms(testNum)
+
+    status = "Fail"
+    timeout_accured = "False"
+    driver = None
+    common = None
+    # Test variables
+
+    typeTest            = "Entitlements of a Private Channel with Owner, Anonymous, Members and Contributor users"
+    
+    normalUser          = "python_normal"
+    memberUser          = "python_member"
+    contributorUser     = "python_contributor"
+    userPassword        = "Kaltura1!"
+    
+    description         = "Description"
+    tags                = "Tags,"
+    entryName           = None
+    entryDescription    = "Private Entry Description"
+    entryTags           = "private,"
+    
+    channelName         = None
+    channelDescription  = "Private Channel Description"
+    channelTags         = "private,"
+
+    # Variables used in order to create a video entry with Slides and Captions
+    filePathVideo = localSettings.LOCAL_SETTINGS_MEDIA_PATH + r'\videos\QR_30_sec_new.mp4'    
+    #run test as different instances on all the supported platforms
+    @pytest.fixture(scope='module',params=supported_platforms)
+    def driverFix(self,request):
+        return request.param
+
+    def test_01(self,driverFix,env):
+        #write to log we started the test
+        logStartTest(self,driverFix)
+        try:
+            ########################### TEST SETUP ###########################
+            #capture test start time
+            self.startTime = time.time()
+            #initialize all the basic vars and start playing
+            self,self.driver = clsTestService.initializeAndLoginAsUser(self, driverFix)
+            self.common = Common(self.driver)
+            # Variables used in order to proper create the Entry
+            self.entryName             = clsTestService.addGuidToString("Entitlements - Private Channel", self.testNum)
+            self.channelName           = clsTestService.addGuidToString("Private Channel", self.testNum)
+            ##################### TEST STEPS - MAIN FLOW #####################
+            writeToLog("INFO","Step 1: Going to create " + self.channelName + " channel as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+            if self.common.channel.createChannel(self.channelName, self.channelDescription, self.channelTags, enums.ChannelPrivacyType.PRIVATE, True, True, True) == False:
+                writeToLog("INFO","Step 1: FAILED to create " + self.channelName + " channel as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+                return
+              
+            writeToLog("INFO","Step 2: Going to add " + self.memberUser + " as member of " + self.channelName)
+            if self.common.channel.addMembersToChannel(self.channelName, self.memberUser, enums.ChannelMemberPermission.MEMBER) == False:
+                writeToLog("INFO","Step 2: FAILED to add " + self.memberUser + " as member of " + self.channelName)
+                return
+             
+            writeToLog("INFO","Step 3: Going to add " + self.contributorUser + " as contributor of " + self.channelName)
+            if self.common.channel.addMembersToChannel(self.channelName, self.contributorUser, enums.ChannelMemberPermission.CONTRIBUTOR) == False:
+                writeToLog("INFO","Step 3: FAILED to add " + self.contributorUser + " as contributor of " + self.channelName)
+                return
+   
+            writeToLog("INFO","Step 4: Going to upload " + self.entryName + " entry as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+            if self.common.upload.uploadEntry(self.filePathVideo, self.entryName, self.entryDescription, self.entryTags, disclaimer=False) == None:
+                writeToLog("INFO","Step 4: FAILED to upload " + self.entryName + " entry as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+                return
+        
+            writeToLog("INFO","Step 5: Going to publish the " + self.entryName + " to the " + self.channelName)
+            if self.common.myMedia.publishSingleEntry(self.entryName, "", self.channelName) == False:
+                writeToLog("INFO","Step 5: FAILED to publish the " + self.entryName + " to the " + self.channelName)
+                return
+                          
+            writeToLog("INFO","Step 6: Going to navigate as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME + " to the " + self.channelName + " channel from Channels Page and access the Add To Channel Tab")
+            if self.common.channel.navigateToAddToChannel(self.channelName, enums.Location.MY_CHANNELS_PAGE) == False:
+                writeToLog("INFO","Step 6: FAILED to navigate as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME + " to the " + self.channelName + " channel from Channels Page and access the Add To Channel Tab")
+                return
+             
+            writeToLog("INFO","Step 7: Going to move to Anonymous user")
+            if self.common.login.logOutOfKMS() == False:
+                writeToLog("INFO","Step 7: FAILED to move to Anonymous user")
+                return
+             
+            writeToLog("INFO","Step 8: Going to verify that Anonymous user is able to access the Channels Page")
+            if self.common.channel.navigateToChannels() == False:
+                writeToLog("INFO","Step 8: FAILED to verify that Anonymous user is able to access the Channels Page")
+                return  
+             
+            writeToLog("INFO","Step 9: Going to verify that Anonymous user is unable to access " + self.channelName)
+            if self.common.channel.navigateToChannel(self.channelName, enums.Location.CHANNELS_PAGE) == True:
+                writeToLog("INFO","Step 9: FAILED to verify that Anonymous user is unable to access " + self.channelName)
+                return
+             
+            writeToLog("INFO","Step 10: Going to authenticate with , " + self.normalUser + " normal KMS user")
+            if self.common.login.loginToKMS(self.normalUser, self.userPassword) == False:
+                writeToLog("INFO","Step 10: FAILED to authenticate with , " + self.normalUser + " normal KMS user")
+                return
+             
+            writeToLog("INFO","Step 11: Going to verify that Normal user " + self.normalUser + " is able to access the Channels Page")
+            if self.common.channel.navigateToChannels() == False:
+                writeToLog("INFO","Step 11: FAILED to verify that Normal user " + self.normalUser + " is able to access the Channels Page")
+                return  
+              
+            writeToLog("INFO","Step 12: Going to verify that Normal user " + self.normalUser + "  is unable to access " + self.channelName)
+            if self.common.channel.navigateToChannel(self.channelName, enums.Location.CHANNELS_PAGE) == True:
+                writeToLog("INFO","Step 12: FAILED to verify that Normal user " + self.normalUser + "  is unable to access " + self.channelName)
+                return
+            
+            writeToLog("INFO","Step 13: Going to log out from " + self.normalUser)
+            if self.common.login.logOutOfKMS() == False:
+                writeToLog("INFO","Step 13: FAILED to log out from " + self.normalUser)
+                return
+            
+            writeToLog("INFO","Step 14: Going to authenticate with , " + self.memberUser + " member KMS user")
+            if self.common.login.loginToKMS(self.memberUser, self.userPassword) == False:
+                writeToLog("INFO","Step 14: FAILED to authenticate with , " + self.memberUser + " member KMS user")
+                return
+            
+            writeToLog("INFO","Step 15: Going to verify that Member user " + self.memberUser + "  is able to access " + self.channelName + " and enter in " + self.entryName)
+            if self.common.channel.navigateToEntryFromChannel(self.channelName, self.entryName, enums.Location.CHANNELS_PAGE) == False:
+                writeToLog("INFO","Step 15: FAILED to verify that Member user " + self.memberUser + "  is able to access " + self.channelName + " and enter in " + self.entryName)
+                return
+            
+            writeToLog("INFO","Step 16: Going to verify that Member user " + self.memberUser + "  is unable to access the 'Add Media Tab' from" + self.channelName)
+            if self.common.channel.navigateToAddToChannel(self.channelName, enums.Location.CHANNELS_PAGE) == True:
+                writeToLog("INFO","Step 16: FAILED " + self.memberUser + " was able to add content to " + self.channelName + " although it should't has permission")
+                return
+            
+            writeToLog("INFO","Step 17: Going to log out from " + self.memberUser)
+            if self.common.login.logOutOfKMS() == False:
+                writeToLog("INFO","Step 17: FAILED to log out from " + self.memberUser)
+                return
+            
+            writeToLog("INFO","Step 18: Going to authenticate with , " + self.contributorUser + " normal KMS user")
+            if self.common.login.loginToKMS(self.contributorUser, self.userPassword) == False:
+                writeToLog("INFO","Step 18: FAILED to authenticate with , " + self.contributorUser + " normal KMS user")
+                return
+            
+            writeToLog("INFO","Step 19: Going to verify that Contributor user " + self.contributorUser + "  is able to access " + self.channelName + " and enter in " + self.entryName)
+            if self.common.channel.navigateToEntryFromChannel(self.channelName, self.entryName, enums.Location.CHANNELS_PAGE) == False:
+                writeToLog("INFO","Step 19: FAILED to verify that Contributor user " + self.contributorUser + "  is able to access " + self.channelName + " and enter in " + self.entryName)
+                return
+            
+            writeToLog("INFO","Step 20: Going to verify that Contributor user " + self.contributorUser + "  is able to access the 'Add Media Tab' from" + self.channelName)
+            if self.common.channel.navigateToAddToChannel(self.channelName, enums.Location.CHANNELS_PAGE) == False:
+                writeToLog("INFO","Step 20: FAILED to verify that Contributor user " + self.contributorUser + "  is able to access the 'Add Media Tab' from " + self.channelName)
+                return
+            ##################################################################
+            self.status="Pass"
+            writeToLog("INFO","TEST PASSED: " + self.typeTest)
+        # if an exception happened we need to handle it and fail the test
+        except Exception as inst:
+            self.status = clsTestService.handleException(self,inst,self.startTime)
+    ########################### TEST TEARDOWN ###########################
+    def teardown_method(self,method):
+        try:
+            self.common.handleTestFail(self.status)
+            writeToLog("INFO","**************** Starting: teardown_method ****************")
+            self.common.login.logOutOfKMS()
+            self.common.login.loginToKMS(localSettings.LOCAL_SETTINGS_LOGIN_USERNAME, localSettings.LOCAL_SETTINGS_LOGIN_PASSWORD)
+            self.common.myMedia.deleteEntriesFromMyMedia(self.entryName)
+            self.common.channel.deleteChannel(self.channelName)
+            writeToLog("INFO","**************** Ended: teardown_method *******************")
+        except:
+            pass
+        clsTestService.basicTearDown(self)
+        #write to log we finished the test
+        logFinishedTest(self,self.startTime)
+        assert (self.status == "Pass")
+
+    pytest.main('test_' + testNum  + '.py --tb=line')

--- a/web/tests/entitlements/test_5009.py
+++ b/web/tests/entitlements/test_5009.py
@@ -1,0 +1,170 @@
+import time, pytest
+import sys,os
+sys.path.insert(1,os.path.abspath(os.path.join(os.path.dirname( __file__ ),'..','..','lib')))
+from clsCommon import Common
+import clsTestService
+from localSettings import *
+import localSettings
+from utilityTestFunc import *
+import enums
+import collections
+
+
+class Test:
+
+    #================================================================================================================================
+    #  @Author: Horia Cus
+    # Test Name : Entitlements - Open Channel using Channels Page 
+    # Test description:
+    # 1. Create an Open Channel
+    # 2. Publish an entry inside the Open Channel
+    # 3. Add a member to the Open channel
+    # 4. Verify that the Channel owner has full control over the Open channel
+    # 5. Verify that the Anonymous user is able to access the Open Channel but unable to Contribute
+    # 6. Verify that Normal KMS users are able to access the Open Channel and contribute
+    #================================================================================================================================
+    testNum = "5009"
+
+    supported_platforms = clsTestService.updatePlatforms(testNum)
+
+    status = "Fail"
+    timeout_accured = "False"
+    driver = None
+    common = None
+    # Test variables
+
+    typeTest            = "Entitlements for an Open Channel with Owner, Anonymous and Members users"
+    
+    normalUser          = "python_normal"
+    memberUser          = "python_member"
+    userPassword        = "Kaltura1!"
+    
+    description         = "Description"
+    tags                = "Tags,"
+    entryName           = None
+    entryDescription    = "Open Entry Description"
+    entryTags           = "open,"
+    
+    channelName         = None
+    channelDescription  = "Open Channel Description"
+    channelTags         = "open,"
+
+    # Variables used in order to create a video entry with Slides and Captions
+    filePathVideo = localSettings.LOCAL_SETTINGS_MEDIA_PATH + r'\videos\QR_30_sec_new.mp4'    
+    #run test as different instances on all the supported platforms
+    @pytest.fixture(scope='module',params=supported_platforms)
+    def driverFix(self,request):
+        return request.param
+
+    def test_01(self,driverFix,env):
+        #write to log we started the test
+        logStartTest(self,driverFix)
+        try:
+            ########################### TEST SETUP ###########################
+            #capture test start time
+            self.startTime = time.time()
+            #initialize all the basic vars and start playing
+            self,self.driver = clsTestService.initializeAndLoginAsUser(self, driverFix)
+            self.common = Common(self.driver)
+            # Variables used in order to proper create the Entry
+            self.entryName             = clsTestService.addGuidToString("Entitlements - Open Channel", self.testNum)
+            self.channelName           = clsTestService.addGuidToString("Open Channel", self.testNum)
+            ##################### TEST STEPS - MAIN FLOW #####################
+            writeToLog("INFO","Step 1: Going to create " + self.channelName + " channel as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+            if self.common.channel.createChannel(self.channelName, self.channelDescription, self.channelTags, enums.ChannelPrivacyType.OPEN, True, True, True) == False:
+                writeToLog("INFO","Step 1: FAILED to create " + self.channelName + " channel as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+                return
+              
+            writeToLog("INFO","Step 2: Going to add " + self.memberUser + " as member of " + self.channelName)
+            if self.common.channel.addMembersToChannel(self.channelName, self.memberUser, enums.ChannelMemberPermission.MEMBER) == False:
+                writeToLog("INFO","Step 2: FAILED to add " + self.memberUser + " as member of " + self.channelName)
+                return
+   
+            writeToLog("INFO","Step 3: Going to upload " + self.entryName + " entry as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+            if self.common.upload.uploadEntry(self.filePathVideo, self.entryName, self.entryDescription, self.entryTags, disclaimer=False) == None:
+                writeToLog("INFO","Step 3: FAILED to upload " + self.entryName + " entry as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+                return
+        
+            writeToLog("INFO","Step 4: Going to publish the " + self.entryName + " to the " + self.channelName)
+            if self.common.myMedia.publishSingleEntry(self.entryName, "", self.channelName) == False:
+                writeToLog("INFO","Step 4: FAILED to publish the " + self.entryName + " to the " + self.channelName)
+                return
+                          
+            writeToLog("INFO","Step 5: Going to navigate as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME + " to the " + self.channelName + " channel from Channels Page and access the Add To Channel Tab")
+            if self.common.channel.navigateToAddToChannel(self.channelName, enums.Location.MY_CHANNELS_PAGE) == False:
+                writeToLog("INFO","Step 5: FAILED to navigate as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME + " to the " + self.channelName + " channel from Channels Page and access the Add To Channel Tab")
+                return
+             
+            writeToLog("INFO","Step 6: Going to move to Anonymous user")
+            if self.common.login.logOutOfKMS() == False:
+                writeToLog("INFO","Step 6: FAILED to move to Anonymous user")
+                return
+                          
+            writeToLog("INFO","Step 7: Going to verify that the Anonymous user is able to access Channels Page")
+            if self.common.channel.navigateToChannels() == False:
+                writeToLog("INFO","Step 7: FAILED to verify that the Anonymous user is able to access Channels Page")
+                return
+            
+            writeToLog("INFO","Step 8: Going to verify that the Anonymous user is unable to access " + self.channelName + " and enter in " + self.entryName)
+            if self.common.channel.navigateToEntryFromChannel(self.channelName, self.entryName, enums.Location.CHANNELS_PAGE) == True:
+                writeToLog("INFO","Step 8: FAILED to verify that the Anonymous user is unable to access " + self.channelName + " and enter in " + self.entryName)
+                return
+             
+            writeToLog("INFO","Step 9: Going to authenticate with , " + self.normalUser + " normal KMS user")
+            if self.common.login.loginToKMS(self.normalUser, self.userPassword) == False:
+                writeToLog("INFO","Step 9: FAILED to authenticate with , " + self.normalUser + " normal KMS user")
+                return
+              
+            writeToLog("INFO","Step 10: Going to verify that Normal user " + self.normalUser + "  is able to access " + self.channelName + " and enter in " + self.entryName)
+            if self.common.channel.navigateToEntryFromChannel(self.channelName, self.entryName, enums.Location.CHANNELS_PAGE) == False:
+                writeToLog("INFO","Step 10: FAILED to verify that Normal user " + self.normalUser + "  is able to access " + self.channelName + " and enter in " + self.entryName)
+                return
+            
+            writeToLog("INFO","Step 11: Going to verify that Normal user " + self.normalUser + "  is able to access the 'Add Media Tab' from" + self.channelName)
+            if self.common.channel.navigateToAddToChannel(self.channelName, enums.Location.CHANNELS_PAGE) == False:
+                writeToLog("INFO","Step 11: FAILED to verify that Normal user " + self.normalUser + "  is able to access the 'Add Media Tab' from " + self.channelName)
+                return
+            
+            writeToLog("INFO","Step 12: Going to log out from " + self.normalUser)
+            if self.common.login.logOutOfKMS() == False:
+                writeToLog("INFO","Step 12: FAILED to log out from " + self.normalUser)
+                return
+            
+            writeToLog("INFO","Step 13: Going to authenticate with , " + self.memberUser + " member KMS user")
+            if self.common.login.loginToKMS(self.memberUser, self.userPassword) == False:
+                writeToLog("INFO","Step 13: FAILED to authenticate with , " + self.memberUser + " member KMS user")
+                return
+            
+            writeToLog("INFO","Step 14: Going to verify that Member user " + self.memberUser + "  is able to access " + self.channelName + " and enter in " + self.entryName)
+            if self.common.channel.navigateToEntryFromChannel(self.channelName, self.entryName, enums.Location.CHANNELS_PAGE) == False:
+                writeToLog("INFO","Step 14: FAILED to verify that Member user " + self.memberUser + "  is able to access " + self.channelName + " and enter in " + self.entryName)
+                return
+            
+            writeToLog("INFO","Step 15: Going to verify that Member user " + self.normalUser + "  is able to access the 'Add Media Tab' from" + self.channelName)
+            if self.common.channel.navigateToAddToChannel(self.channelName, enums.Location.CHANNELS_PAGE) == False:
+                writeToLog("INFO","Step 15: FAILED to verify that Member user " + self.normalUser + "  is able to access the 'Add Media Tab' from " + self.channelName)
+                return
+            ##################################################################
+            self.status="Pass"
+            writeToLog("INFO","TEST PASSED: " + self.typeTest)
+        # if an exception happened we need to handle it and fail the test
+        except Exception as inst:
+            self.status = clsTestService.handleException(self,inst,self.startTime)
+    ########################### TEST TEARDOWN ###########################
+    def teardown_method(self,method):
+        try:
+            self.common.handleTestFail(self.status)
+            writeToLog("INFO","**************** Starting: teardown_method ****************")
+            self.common.login.logOutOfKMS()
+            self.common.login.loginToKMS(localSettings.LOCAL_SETTINGS_LOGIN_USERNAME, localSettings.LOCAL_SETTINGS_LOGIN_PASSWORD)
+            self.common.myMedia.deleteEntriesFromMyMedia(self.entryName)
+            self.common.channel.deleteChannel(self.channelName)
+            writeToLog("INFO","**************** Ended: teardown_method *******************")
+        except:
+            pass
+        clsTestService.basicTearDown(self)
+        #write to log we finished the test
+        logFinishedTest(self,self.startTime)
+        assert (self.status == "Pass")
+
+    pytest.main('test_' + testNum  + '.py --tb=line')

--- a/web/tests/entitlements/test_5010.py
+++ b/web/tests/entitlements/test_5010.py
@@ -1,0 +1,198 @@
+import time, pytest
+import sys,os
+sys.path.insert(1,os.path.abspath(os.path.join(os.path.dirname( __file__ ),'..','..','lib')))
+from clsCommon import Common
+import clsTestService
+from localSettings import *
+import localSettings
+from utilityTestFunc import *
+import enums
+import collections
+
+
+class Test:
+
+    #================================================================================================================================
+    #  @Author: Horia Cus
+    # Test Name : Entitlements - Restricted Channel using Channels Page 
+    # Test description:
+    # 1. Create a Restricted Channel
+    # 2. Publish an entry inside the Private Channel
+    # 3. Add a member and a contributor to the Restricted channel
+    # 4. Verify that the Channel owner has full control over the Restricted channel
+    # 5. Verify that the Anonymous user is unable to enter to the Restricted Channel
+    # 6. Verify that Logged in KMS users are able to access the Restricted Channel
+    # 7. Verify that Member users are able to access the Restricted Channel but unable to add new content
+    # 8. Verify that Contributor users are able to access the Restricted Channel and add new content
+    #================================================================================================================================
+    testNum = "5010"
+
+    supported_platforms = clsTestService.updatePlatforms(testNum)
+
+    status = "Fail"
+    timeout_accured = "False"
+    driver = None
+    common = None
+    # Test variables
+
+    typeTest            = "Entitlements of a Restricted Channel with Owner, Anonymous, Members and Contributor users"
+    
+    normalUser          = "python_normal"
+    memberUser          = "python_member"
+    contributorUser     = "python_contributor"
+    userPassword        = "Kaltura1!"
+    
+    description         = "Description"
+    tags                = "Tags,"
+    entryName           = None
+    entryDescription    = "Restricted Entry Description"
+    entryTags           = "restricted,"
+    
+    channelName         = None
+    channelDescription  = "Restricted Channel Description"
+    channelTags         = "restricted,"
+
+    # Variables used in order to create a video entry with Slides and Captions
+    filePathVideo = localSettings.LOCAL_SETTINGS_MEDIA_PATH + r'\videos\QR_30_sec_new.mp4'    
+    #run test as different instances on all the supported platforms
+    @pytest.fixture(scope='module',params=supported_platforms)
+    def driverFix(self,request):
+        return request.param
+
+    def test_01(self,driverFix,env):
+        #write to log we started the test
+        logStartTest(self,driverFix)
+        try:
+            ########################### TEST SETUP ###########################
+            #capture test start time
+            self.startTime = time.time()
+            #initialize all the basic vars and start playing
+            self,self.driver = clsTestService.initializeAndLoginAsUser(self, driverFix)
+            self.common = Common(self.driver)
+            # Variables used in order to proper create the Entry
+            self.entryName             = clsTestService.addGuidToString("Entitlements - Restricted Channel", self.testNum)
+            self.channelName           = clsTestService.addGuidToString("Restricted Channel", self.testNum)
+            ##################### TEST STEPS - MAIN FLOW #####################
+            writeToLog("INFO","Step 1: Going to create " + self.channelName + " channel as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+            if self.common.channel.createChannel(self.channelName, self.channelDescription, self.channelTags, enums.ChannelPrivacyType.RESTRICTED, True, True, True) == False:
+                writeToLog("INFO","Step 1: FAILED to create " + self.channelName + " channel as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+                return
+              
+            writeToLog("INFO","Step 2: Going to add " + self.memberUser + " as member of " + self.channelName)
+            if self.common.channel.addMembersToChannel(self.channelName, self.memberUser, enums.ChannelMemberPermission.MEMBER) == False:
+                writeToLog("INFO","Step 2: FAILED to add " + self.memberUser + " as member of " + self.channelName)
+                return
+             
+            writeToLog("INFO","Step 3: Going to add " + self.contributorUser + " as contributor of " + self.channelName)
+            if self.common.channel.addMembersToChannel(self.channelName, self.contributorUser, enums.ChannelMemberPermission.CONTRIBUTOR) == False:
+                writeToLog("INFO","Step 3: FAILED to add " + self.contributorUser + " as contributor of " + self.channelName)
+                return
+   
+            writeToLog("INFO","Step 4: Going to upload " + self.entryName + " entry as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+            if self.common.upload.uploadEntry(self.filePathVideo, self.entryName, self.entryDescription, self.entryTags, disclaimer=False) == None:
+                writeToLog("INFO","Step 4: FAILED to upload " + self.entryName + " entry as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+                return
+        
+            writeToLog("INFO","Step 5: Going to publish the " + self.entryName + " to the " + self.channelName)
+            if self.common.myMedia.publishSingleEntry(self.entryName, "", self.channelName) == False:
+                writeToLog("INFO","Step 5: FAILED to publish the " + self.entryName + " to the " + self.channelName)
+                return
+                          
+            writeToLog("INFO","Step 6: Going to navigate as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME + " to the " + self.channelName + " channel from Channels Page and access the Add To Channel Tab")
+            if self.common.channel.navigateToAddToChannel(self.channelName, enums.Location.MY_CHANNELS_PAGE) == False:
+                writeToLog("INFO","Step 6: FAILED to navigate as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME + " to the " + self.channelName + " channel from Channels Page and access the Add To Channel Tab")
+                return
+             
+            writeToLog("INFO","Step 7: Going to move to Anonymous user")
+            if self.common.login.logOutOfKMS() == False:
+                writeToLog("INFO","Step 7: FAILED to move to Anonymous user")
+                return
+             
+            writeToLog("INFO","Step 8: Going to verify that Anonymous user is able to access the Channels Page")
+            if self.common.channel.navigateToChannels() == False:
+                writeToLog("INFO","Step 8: FAILED to verify that Anonymous user is able to access the Channels Page")
+                return  
+             
+            writeToLog("INFO","Step 9: Going to verify that Anonymous user is unable to access " + self.channelName)
+            if self.common.channel.navigateToChannel(self.channelName, enums.Location.CHANNELS_PAGE) == True:
+                writeToLog("INFO","Step 9: FAILED to verify that Anonymous user is unable to access " + self.channelName)
+                return
+             
+            writeToLog("INFO","Step 10: Going to authenticate with , " + self.normalUser + " normal KMS user")
+            if self.common.login.loginToKMS(self.normalUser, self.userPassword) == False:
+                writeToLog("INFO","Step 10: FAILED to authenticate with , " + self.normalUser + " normal KMS user")
+                return
+             
+            writeToLog("INFO","Step 11: Going to verify that Normal user " + self.normalUser + "  is able to access " + self.channelName + " and enter in " + self.entryName)
+            if self.common.channel.navigateToEntryFromChannel(self.channelName, self.entryName, enums.Location.CHANNELS_PAGE) == False:
+                writeToLog("INFO","Step 11: FAILED to verify that Normal user " + self.normalUser + "  is able to access " + self.channelName + " and enter in " + self.entryName)
+                return
+            
+            writeToLog("INFO","Step 12: Going to verify that Normal user " + self.normalUser + "  is unable to access the 'Add Media Tab' from" + self.channelName)
+            if self.common.channel.navigateToAddToChannel(self.channelName, enums.Location.CHANNELS_PAGE) == True:
+                writeToLog("INFO","Step 12: FAILED to verify that Normal user " + self.normalUser + "  is unable to access the 'Add Media Tab' from " + self.channelName)
+                return
+            
+            writeToLog("INFO","Step 13: Going to log out from " + self.normalUser)
+            if self.common.login.logOutOfKMS() == False:
+                writeToLog("INFO","Step 13: FAILED to log out from " + self.normalUser)
+                return
+            
+            writeToLog("INFO","Step 14: Going to authenticate with , " + self.memberUser + " member KMS user")
+            if self.common.login.loginToKMS(self.memberUser, self.userPassword) == False:
+                writeToLog("INFO","Step 14: FAILED to authenticate with , " + self.memberUser + " member KMS user")
+                return
+            
+            writeToLog("INFO","Step 15: Going to verify that Member user " + self.memberUser + "  is able to access " + self.channelName + " and enter in " + self.entryName)
+            if self.common.channel.navigateToEntryFromChannel(self.channelName, self.entryName, enums.Location.CHANNELS_PAGE) == False:
+                writeToLog("INFO","Step 15: FAILED to verify that Member user " + self.memberUser + "  is able to access " + self.channelName + " and enter in " + self.entryName)
+                return
+            
+            writeToLog("INFO","Step 16: Going to verify that Member user " + self.memberUser + "  is unable to access the 'Add Media Tab' from" + self.channelName)
+            if self.common.channel.navigateToAddToChannel(self.channelName, enums.Location.CHANNELS_PAGE) == True:
+                writeToLog("INFO","Step 16: FAILED to verify that Member user " + self.memberUser + "  is unable to access the 'Add Media Tab' from" + self.channelName)
+                return
+            
+            writeToLog("INFO","Step 17: Going to log out from " + self.memberUser)
+            if self.common.login.logOutOfKMS() == False:
+                writeToLog("INFO","Step 17: FAILED to log out from " + self.memberUser)
+                return
+            
+            writeToLog("INFO","Step 18: Going to authenticate with , " + self.contributorUser + " normal KMS user")
+            if self.common.login.loginToKMS(self.contributorUser, self.userPassword) == False:
+                writeToLog("INFO","Step 18: FAILED to authenticate with , " + self.contributorUser + " normal KMS user")
+                return
+            
+            writeToLog("INFO","Step 19: Going to verify that Contributor user " + self.contributorUser + "  is able to access " + self.channelName + " and enter in " + self.entryName)
+            if self.common.channel.navigateToEntryFromChannel(self.channelName, self.entryName, enums.Location.CHANNELS_PAGE) == False:
+                writeToLog("INFO","Step 19: FAILED to verify that Contributor user " + self.contributorUser + "  is able to access " + self.channelName + " and enter in " + self.entryName)
+                return
+            
+            writeToLog("INFO","Step 20: Going to verify that Contributor user " + self.contributorUser + "  is able to access the 'Add Media Tab' from" + self.channelName)
+            if self.common.channel.navigateToAddToChannel(self.channelName, enums.Location.CHANNELS_PAGE) == False:
+                writeToLog("INFO","Step 20: FAILED to verify that Contributor user " + self.contributorUser + "  is able to access the 'Add Media Tab' from " + self.channelName)
+                return
+            ##################################################################
+            self.status="Pass"
+            writeToLog("INFO","TEST PASSED: " + self.typeTest)
+        # if an exception happened we need to handle it and fail the test
+        except Exception as inst:
+            self.status = clsTestService.handleException(self,inst,self.startTime)
+    ########################### TEST TEARDOWN ###########################
+    def teardown_method(self,method):
+        try:
+            self.common.handleTestFail(self.status)
+            writeToLog("INFO","**************** Starting: teardown_method ****************")
+            self.common.login.logOutOfKMS()
+            self.common.login.loginToKMS(localSettings.LOCAL_SETTINGS_LOGIN_USERNAME, localSettings.LOCAL_SETTINGS_LOGIN_PASSWORD)
+            self.common.myMedia.deleteEntriesFromMyMedia(self.entryName)
+            self.common.channel.deleteChannel(self.channelName)
+            writeToLog("INFO","**************** Ended: teardown_method *******************")
+        except:
+            pass
+        clsTestService.basicTearDown(self)
+        #write to log we finished the test
+        logFinishedTest(self,self.startTime)
+        assert (self.status == "Pass")
+
+    pytest.main('test_' + testNum  + '.py --tb=line')

--- a/web/tests/entitlements/test_5011.py
+++ b/web/tests/entitlements/test_5011.py
@@ -1,0 +1,197 @@
+import time, pytest
+import sys,os
+sys.path.insert(1,os.path.abspath(os.path.join(os.path.dirname( __file__ ),'..','..','lib')))
+from clsCommon import Common
+import clsTestService
+from localSettings import *
+import localSettings
+from utilityTestFunc import *
+import enums
+import collections
+
+
+class Test:
+
+    #================================================================================================================================
+    #  @Author: Horia Cus
+    # Test Name : Entitlements - Shared Repository Channel using Channels Page 
+    # Test description:
+    # 1. Create a Shared Repository Channel
+    # 2. Publish an entry inside the Shared Repository Channel
+    # 3. Add a member and a contributor to the Shared Repository channel
+    # 4. Verify that the Channel owner has full control over the Shared Repository channel
+    # 5. Verify that the Anonymous user and KMS User are unable to access the Shared Repository Channel
+    # 6. Verify that the Channel Member have access to the Shared Repository Channel content but are unable to add content
+    # 7. Verify that the Contributor Member is able to access and add content to the Shared Repository Channel
+    #================================================================================================================================
+    testNum = "5011"
+
+    supported_platforms = clsTestService.updatePlatforms(testNum)
+
+    status = "Fail"
+    timeout_accured = "False"
+    driver = None
+    common = None
+    # Test variables
+
+    typeTest            = "Entitlements of a Shared Repository Channel with Owner, Anonymous, Members and Contributor users"
+    
+    normalUser          = "python_normal"
+    memberUser          = "python_member"
+    contributorUser     = "python_contributor"
+    userPassword        = "Kaltura1!"
+    
+    description         = "Description"
+    tags                = "Tags,"
+    entryName           = None
+    entryDescription    = "Shared Entry Description"
+    entryTags           = "shared,"
+    
+    channelName         = None
+    channelDescription  = "Shared Repository Channel Description"
+    channelTags         = "shared,"
+
+    # Variables used in order to create a video entry with Slides and Captions
+    filePathVideo = localSettings.LOCAL_SETTINGS_MEDIA_PATH + r'\videos\QR_30_sec_new.mp4'    
+    #run test as different instances on all the supported platforms
+    @pytest.fixture(scope='module',params=supported_platforms)
+    def driverFix(self,request):
+        return request.param
+
+    def test_01(self,driverFix,env):
+        #write to log we started the test
+        logStartTest(self,driverFix)
+        try:
+            ########################### TEST SETUP ###########################
+            #capture test start time
+            self.startTime = time.time()
+            #initialize all the basic vars and start playing
+            self,self.driver = clsTestService.initializeAndLoginAsUser(self, driverFix)
+            self.common = Common(self.driver)
+            # Variables used in order to proper create the Entry
+            self.entryName             = clsTestService.addGuidToString("Entitlements - Shared Repository Channel", self.testNum)
+            self.channelName           = clsTestService.addGuidToString("Shared Repository Channel", self.testNum)
+            ##################### TEST STEPS - MAIN FLOW #####################
+            writeToLog("INFO","Step 1: Going to create " + self.channelName + " channel as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+            if self.common.channel.createChannel(self.channelName, self.channelDescription, self.channelTags, enums.ChannelPrivacyType.SHAREDREPOSITORY, True, True, True) == False:
+                writeToLog("INFO","Step 1: FAILED to create " + self.channelName + " channel as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+                return
+              
+            writeToLog("INFO","Step 2: Going to add " + self.memberUser + " as member of " + self.channelName)
+            if self.common.channel.addMembersToChannel(self.channelName, self.memberUser, enums.ChannelMemberPermission.MEMBER) == False:
+                writeToLog("INFO","Step 2: FAILED to add " + self.memberUser + " as member of " + self.channelName)
+                return
+             
+            writeToLog("INFO","Step 3: Going to add " + self.contributorUser + " as contributor of " + self.channelName)
+            if self.common.channel.addMembersToChannel(self.channelName, self.contributorUser, enums.ChannelMemberPermission.CONTRIBUTOR) == False:
+                writeToLog("INFO","Step 3: FAILED to add " + self.contributorUser + " as contributor of " + self.channelName)
+                return
+   
+            writeToLog("INFO","Step 4: Going to upload " + self.entryName + " entry as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+            if self.common.upload.uploadEntry(self.filePathVideo, self.entryName, self.entryDescription, self.entryTags, disclaimer=False) == None:
+                writeToLog("INFO","Step 4: FAILED to upload " + self.entryName + " entry as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+                return
+        
+            writeToLog("INFO","Step 5: Going to publish the " + self.entryName + " to the " + self.channelName)
+            if self.common.myMedia.publishSingleEntry(self.entryName, "", self.channelName) == False:
+                writeToLog("INFO","Step 5: FAILED to publish the " + self.entryName + " to the " + self.channelName)
+                return
+                          
+            writeToLog("INFO","Step 6: Going to navigate as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME + " to the " + self.channelName + " channel from Channels Page and access the Add To Channel Tab")
+            if self.common.channel.navigateToAddToChannel(self.channelName, enums.Location.MY_CHANNELS_PAGE) == False:
+                writeToLog("INFO","Step 6: FAILED to navigate as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME + " to the " + self.channelName + " channel from Channels Page and access the Add To Channel Tab")
+                return
+             
+            writeToLog("INFO","Step 7: Going to move to Anonymous user")
+            if self.common.login.logOutOfKMS() == False:
+                writeToLog("INFO","Step 7: FAILED to move to Anonymous user")
+                return
+             
+            writeToLog("INFO","Step 8: Going to verify that Anonymous user is able to access the Channels Page")
+            if self.common.channel.navigateToChannels() == False:
+                writeToLog("INFO","Step 8: FAILED to verify that Anonymous user is able to access the Channels Page")
+                return  
+             
+            writeToLog("INFO","Step 9: Going to verify that Anonymous user is unable to access " + self.channelName)
+            if self.common.channel.navigateToChannel(self.channelName, enums.Location.CHANNELS_PAGE) == True:
+                writeToLog("INFO","Step 9: FAILED to verify that Anonymous user is unable to access " + self.channelName)
+                return
+             
+            writeToLog("INFO","Step 10: Going to authenticate with , " + self.normalUser + " normal KMS user")
+            if self.common.login.loginToKMS(self.normalUser, self.userPassword) == False:
+                writeToLog("INFO","Step 10: FAILED to authenticate with , " + self.normalUser + " normal KMS user")
+                return
+             
+            writeToLog("INFO","Step 11: Going to verify that Normal user " + self.normalUser + " is able to access the Channels Page")
+            if self.common.channel.navigateToChannels() == False:
+                writeToLog("INFO","Step 11: FAILED to verify that Normal user " + self.normalUser + " is able to access the Channels Page")
+                return  
+              
+            writeToLog("INFO","Step 12: Going to verify that Normal user " + self.normalUser + "  is unable to access " + self.channelName)
+            if self.common.channel.navigateToChannel(self.channelName, enums.Location.CHANNELS_PAGE) == True:
+                writeToLog("INFO","Step 12: FAILED to verify that Normal user " + self.normalUser + "  is unable to access " + self.channelName)
+                return
+            
+            writeToLog("INFO","Step 13: Going to log out from " + self.normalUser)
+            if self.common.login.logOutOfKMS() == False:
+                writeToLog("INFO","Step 13: FAILED to log out from " + self.normalUser)
+                return
+            
+            writeToLog("INFO","Step 14: Going to authenticate with , " + self.memberUser + " member KMS user")
+            if self.common.login.loginToKMS(self.memberUser, self.userPassword) == False:
+                writeToLog("INFO","Step 14: FAILED to authenticate with , " + self.memberUser + " member KMS user")
+                return
+            
+            writeToLog("INFO","Step 15: Going to verify that Member user " + self.memberUser + "  is able to access " + self.channelName + " and enter in " + self.entryName)
+            if self.common.channel.navigateToEntryFromChannel(self.channelName, self.entryName, enums.Location.CHANNELS_PAGE) == False:
+                writeToLog("INFO","Step 15: FAILED to verify that Member user " + self.memberUser + "  is able to access " + self.channelName + " and enter in " + self.entryName)
+                return
+            
+            writeToLog("INFO","Step 16: Going to verify that Member user " + self.memberUser + "  is unable to access the 'Add Media Tab' from" + self.channelName)
+            if self.common.channel.navigateToAddToChannel(self.channelName, enums.Location.CHANNELS_PAGE) == True:
+                writeToLog("INFO","Step 16: FAILED to verify that Member user " + self.memberUser + "  is unable to access the 'Add Media Tab' from" + self.channelName)
+                return
+            
+            writeToLog("INFO","Step 17: Going to log out from " + self.memberUser)
+            if self.common.login.logOutOfKMS() == False:
+                writeToLog("INFO","Step 17: FAILED to log out from " + self.memberUser)
+                return
+            
+            writeToLog("INFO","Step 18: Going to authenticate with , " + self.contributorUser + " normal KMS user")
+            if self.common.login.loginToKMS(self.contributorUser, self.userPassword) == False:
+                writeToLog("INFO","Step 18: FAILED to authenticate with , " + self.contributorUser + " normal KMS user")
+                return
+            
+            writeToLog("INFO","Step 19: Going to verify that Contributor user " + self.contributorUser + "  is able to access " + self.channelName + " and enter in " + self.entryName)
+            if self.common.channel.navigateToEntryFromChannel(self.channelName, self.entryName, enums.Location.CHANNELS_PAGE) == False:
+                writeToLog("INFO","Step 19: FAILED to verify that Contributor user " + self.contributorUser + "  is able to access " + self.channelName + " and enter in " + self.entryName)
+                return
+            
+            writeToLog("INFO","Step 20: Going to verify that Contributor user " + self.contributorUser + "  is able to access the 'Add Media Tab' from" + self.channelName)
+            if self.common.channel.navigateToAddToChannel(self.channelName, enums.Location.CHANNELS_PAGE) == False:
+                writeToLog("INFO","Step 20: FAILED to verify that Contributor user " + self.contributorUser + "  is able to access the 'Add Media Tab' from " + self.channelName)
+                return
+            ##################################################################
+            self.status="Pass"
+            writeToLog("INFO","TEST PASSED: " + self.typeTest)
+        # if an exception happened we need to handle it and fail the test
+        except Exception as inst:
+            self.status = clsTestService.handleException(self,inst,self.startTime)
+    ########################### TEST TEARDOWN ###########################
+    def teardown_method(self,method):
+        try:
+            self.common.handleTestFail(self.status)
+            writeToLog("INFO","**************** Starting: teardown_method ****************")
+            self.common.login.logOutOfKMS()
+            self.common.login.loginToKMS(localSettings.LOCAL_SETTINGS_LOGIN_USERNAME, localSettings.LOCAL_SETTINGS_LOGIN_PASSWORD)
+            self.common.myMedia.deleteEntriesFromMyMedia(self.entryName)
+            self.common.channel.deleteChannel(self.channelName)
+            writeToLog("INFO","**************** Ended: teardown_method *******************")
+        except:
+            pass
+        clsTestService.basicTearDown(self)
+        #write to log we finished the test
+        logFinishedTest(self,self.startTime)
+        assert (self.status == "Pass")
+
+    pytest.main('test_' + testNum  + '.py --tb=line')

--- a/web/tests/entitlements/test_5012.py
+++ b/web/tests/entitlements/test_5012.py
@@ -1,0 +1,200 @@
+import time, pytest
+import sys,os
+sys.path.insert(1,os.path.abspath(os.path.join(os.path.dirname( __file__ ),'..','..','lib')))
+from clsCommon import Common
+import clsTestService
+from localSettings import *
+import localSettings
+from utilityTestFunc import *
+import enums
+import collections
+
+
+class Test:
+
+    #================================================================================================================================
+    #  @Author: Horia Cus
+    # Test Name : Entitlements - Public Channel using Channels Page and Anonymous Users ON
+    # Test description:
+    # 1. Create a Public Channel
+    # 2. Publish an entry inside the Public Channel
+    # 3. Add a member and a contributor to the Public channel
+    # 4. Verify that the Channel owner has full control over the Public channel
+    # 5. Verify that the Anonymous user and KMS User, Channel Members are able to access the Public Channel but unable to add content
+    # 6. Verify that the Contributor Member is able to access and add content to the Shared Repository Channel
+    #================================================================================================================================
+    testNum = "5012"
+
+    supported_platforms = clsTestService.updatePlatforms(testNum)
+
+    status = "Fail"
+    timeout_accured = "False"
+    driver = None
+    common = None
+    # Test variables
+
+    typeTest            = "Entitlements of a Public Channel with Owner, Anonymous, Members and Contributor users"
+    instanceURL         = None
+    
+    normalUser          = "python_normal"
+    memberUser          = "python_member"
+    contributorUser     = "python_contributor"
+    userPassword        = "Kaltura1!"
+    
+    description         = "Description"
+    tags                = "Tags,"
+    entryName           = None
+    entryDescription    = "Public Entry Description"
+    entryTags           = "public,"
+    
+    channelName         = None
+    channelDescription  = "Public Channel Description"
+    channelTags         = "public,"
+
+    # Variables used in order to create a video entry with Slides and Captions
+    filePathVideo = localSettings.LOCAL_SETTINGS_MEDIA_PATH + r'\videos\QR_30_sec_new.mp4'    
+    #run test as different instances on all the supported platforms
+    @pytest.fixture(scope='module',params=supported_platforms)
+    def driverFix(self,request):
+        return request.param
+
+    def test_01(self,driverFix,env):
+        #write to log we started the test
+        logStartTest(self,driverFix)
+        try:
+            ########################### TEST SETUP ###########################
+            #capture test start time
+            self.startTime = time.time()
+            #initialize all the basic vars and start playing
+            self,self.driver = clsTestService.initializeAndLoginAsUser(self, driverFix)
+            self.common = Common(self.driver)
+            # Variables used in order to proper create the Entry
+            self.entryName             = clsTestService.addGuidToString("Entitlements - Public Channel Anonymous ON", self.testNum)
+            self.channelName           = clsTestService.addGuidToString("Public Channel Anonymous ON", self.testNum)
+            self.instanceUrl = self.common.base.driver.current_url
+            self.common.admin.allowAnonymous(True)
+            self.common.base.navigate(self.instanceUrl)
+            ##################### TEST STEPS - MAIN FLOW #####################
+            writeToLog("INFO","Step 1: Going to create " + self.channelName + " channel as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+            if self.common.channel.createChannel(self.channelName, self.channelDescription, self.channelTags, enums.ChannelPrivacyType.PUBLIC, True, True, True) == False:
+                writeToLog("INFO","Step 1: FAILED to create " + self.channelName + " channel as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+                return
+              
+            writeToLog("INFO","Step 2: Going to add " + self.memberUser + " as member of " + self.channelName)
+            if self.common.channel.addMembersToChannel(self.channelName, self.memberUser, enums.ChannelMemberPermission.MEMBER) == False:
+                writeToLog("INFO","Step 2: FAILED to add " + self.memberUser + " as member of " + self.channelName)
+                return
+            
+            writeToLog("INFO","Step 3: Going to add " + self.contributorUser + " as member of " + self.channelName)
+            if self.common.channel.addMembersToChannel(self.channelName, self.contributorUser, enums.ChannelMemberPermission.CONTRIBUTOR) == False:
+                writeToLog("INFO","Step 3: FAILED to add " + self.contributorUser + " as member of " + self.channelName)
+                return
+                
+            writeToLog("INFO","Step 4: Going to upload " + self.entryName + " entry as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+            if self.common.upload.uploadEntry(self.filePathVideo, self.entryName, self.entryDescription, self.entryTags, disclaimer=False) == None:
+                writeToLog("INFO","Step 4: FAILED to upload " + self.entryName + " entry as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+                return
+        
+            writeToLog("INFO","Step 5: Going to publish the " + self.entryName + " to the " + self.channelName)
+            if self.common.myMedia.publishSingleEntry(self.entryName, "", self.channelName) == False:
+                writeToLog("INFO","Step 5: FAILED to publish the " + self.entryName + " to the " + self.channelName)
+                return
+                          
+            writeToLog("INFO","Step 6: Going to navigate as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME + " to the " + self.channelName + " channel from Channels Page and access the Add To Channel Tab")
+            if self.common.channel.navigateToAddToChannel(self.channelName, enums.Location.MY_CHANNELS_PAGE) == False:
+                writeToLog("INFO","Step 6: FAILED to navigate as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME + " to the " + self.channelName + " channel from Channels Page and access the Add To Channel Tab")
+                return
+             
+            writeToLog("INFO","Step 7: Going to move to Anonymous user")
+            if self.common.login.logOutOfKMS() == False:
+                writeToLog("INFO","Step 7: FAILED to move to Anonymous user")
+                return
+                          
+            writeToLog("INFO","Step 8: Going to verify that Anonymous user is able to access " + self.channelName + " and enter in " + self.entryName)
+            if self.common.channel.navigateToEntryFromChannel(self.channelName, self.entryName, enums.Location.CHANNELS_PAGE) == False:
+                writeToLog("INFO","Step 8: FAILED to verify that Anonymous user is able to access " + self.channelName + " and enter in " + self.entryName)
+                return
+            
+            writeToLog("INFO","Step 9: Going to verify that Anonymous user is unable to access the 'Add Media Tab' from" + self.channelName)
+            if self.common.channel.navigateToAddToChannel(self.channelName, enums.Location.CHANNELS_PAGE) == True:
+                writeToLog("INFO","Step 9: FAILED, the Anonymous User was able to access the Add Media Tab, although he shouldn't have permission")
+                return
+             
+            writeToLog("INFO","Step 10: Going to authenticate with , " + self.normalUser + " normal KMS user")
+            if self.common.login.loginToKMS(self.normalUser, self.userPassword) == False:
+                writeToLog("INFO","Step 10: FAILED to authenticate with , " + self.normalUser + " normal KMS user")
+                return
+             
+            writeToLog("INFO","Step 11: Going to verify that Normal user " + self.normalUser + "  is able to access " + self.channelName + " and enter in " + self.entryName)
+            if self.common.channel.navigateToEntryFromChannel(self.channelName, self.entryName, enums.Location.CHANNELS_PAGE) == False:
+                writeToLog("INFO","Step 11: FAILED to verify that Normal user " + self.normalUser + "  is able to access " + self.channelName + " and enter in " + self.entryName)
+                return
+            
+            writeToLog("INFO","Step 12: Going to verify that the Normal user " + self.normalUser + " is unable to access the 'Add Media Tab' from" + self.channelName)
+            if self.common.channel.navigateToAddToChannel(self.channelName, enums.Location.CHANNELS_PAGE) == True:
+                writeToLog("INFO","Step 12: FAILED the Normal user " + self.normalUser + " was able to access the 'Add Media Tab' from" + self.channelName)
+                return
+            
+            writeToLog("INFO","Step 13: Going to log out from " + self.normalUser)
+            if self.common.login.logOutOfKMS() == False:
+                writeToLog("INFO","Step 13: FAILED to log out from " + self.normalUser)
+                return
+            
+            writeToLog("INFO","Step 14: Going to authenticate with , " + self.memberUser + " member KMS user")
+            if self.common.login.loginToKMS(self.memberUser, self.userPassword) == False:
+                writeToLog("INFO","Step 14: FAILED to authenticate with , " + self.memberUser + " member KMS user")
+                return
+            
+            writeToLog("INFO","Step 15: Going to verify that Member user " + self.memberUser + "  is able to access " + self.channelName + " and enter in " + self.entryName)
+            if self.common.channel.navigateToEntryFromChannel(self.channelName, self.entryName, enums.Location.CHANNELS_PAGE) == False:
+                writeToLog("INFO","Step 15: FAILED to verify that Member user " + self.memberUser + "  is able to access " + self.channelName + " and enter in " + self.entryName)
+                return
+            
+            writeToLog("INFO","Step 16: Going to verify that the Member user " + self.memberUser + " is unable to access the 'Add Media Tab' for" + self.channelName)
+            if self.common.channel.navigateToAddToChannel(self.channelName, enums.Location.CHANNELS_PAGE) == True:
+                writeToLog("INFO","Step 16: FAILED the Member user " + self.memberUser + " was able to access the 'Add Media Tab' for" + self.channelName)
+                return
+            
+            writeToLog("INFO","Step 17: Going to log out from " + self.memberUser)
+            if self.common.login.logOutOfKMS() == False:
+                writeToLog("INFO","Step 17: FAILED to log out from " + self.memberUser)
+                return
+            
+            writeToLog("INFO","Step 18: Going to authenticate with , " + self.contributorUser + " normal KMS user")
+            if self.common.login.loginToKMS(self.contributorUser, self.userPassword) == False:
+                writeToLog("INFO","Step 18: FAILED to authenticate with , " + self.contributorUser + " normal KMS user")
+                return
+            
+            writeToLog("INFO","Step 19: Going to verify that Contributor user " + self.contributorUser + "  is able to access " + self.channelName + " and enter in " + self.entryName)
+            if self.common.channel.navigateToEntryFromChannel(self.channelName, self.entryName, enums.Location.CHANNELS_PAGE) == False:
+                writeToLog("INFO","Step 19: FAILED to verify that Contributor user " + self.contributorUser + "  is able to access " + self.channelName + " and enter in " + self.entryName)
+                return
+            
+            writeToLog("INFO","Step 20: Going to verify that Contributor user " + self.contributorUser + "  is able to access the 'Add Media Tab' for" + self.channelName)
+            if self.common.channel.navigateToAddToChannel(self.channelName, enums.Location.CHANNELS_PAGE) == False:
+                writeToLog("INFO","Step 20: FAILED the " + self.contributorUser + "  was unable to access the 'Add Media Tab' for " + self.channelName)
+                return
+            ##################################################################
+            self.status="Pass"
+            writeToLog("INFO","TEST PASSED: " + self.typeTest)
+        # if an exception happened we need to handle it and fail the test
+        except Exception as inst:
+            self.status = clsTestService.handleException(self,inst,self.startTime)
+    ########################### TEST TEARDOWN ###########################
+    def teardown_method(self,method):
+        try:
+            self.common.handleTestFail(self.status)
+            writeToLog("INFO","**************** Starting: teardown_method ****************")
+            self.common.login.logOutOfKMS()
+            self.common.login.loginToKMS(localSettings.LOCAL_SETTINGS_LOGIN_USERNAME, localSettings.LOCAL_SETTINGS_LOGIN_PASSWORD)
+            self.common.myMedia.deleteEntriesFromMyMedia(self.entryName)
+            self.common.channel.deleteChannel(self.channelName)
+            writeToLog("INFO","**************** Ended: teardown_method *******************")
+        except:
+            pass
+        clsTestService.basicTearDown(self)
+        #write to log we finished the test
+        logFinishedTest(self,self.startTime)
+        assert (self.status == "Pass")
+
+    pytest.main('test_' + testNum  + '.py --tb=line')

--- a/web/tests/entitlements/test_5013.py
+++ b/web/tests/entitlements/test_5013.py
@@ -1,0 +1,197 @@
+import time, pytest
+import sys,os
+sys.path.insert(1,os.path.abspath(os.path.join(os.path.dirname( __file__ ),'..','..','lib')))
+from clsCommon import Common
+import clsTestService
+from localSettings import *
+import localSettings
+from utilityTestFunc import *
+import enums
+import collections
+
+
+class Test:
+
+    #================================================================================================================================
+    #  @Author: Horia Cus
+    # Test Name : Entitlements - Public Channel using Channels Page and Anonymous Users OFF
+    # Test description:
+    # 1. Create a Public Channel
+    # 2. Publish an entry inside the Public Channel
+    # 3. Add a member and a contributor to the Public channel
+    # 4. Verify that the Channel owner has full control over the Public channel
+    # 5. Verify that the KMS User, Channel Members are able to access the Public Channel but unable to add content
+    # 6. Verify that the Contributor Member is able to access and add content to the Shared Repository Channel
+    # 7. Verify that Anonymous Users are unable to access the Channels Page
+    #================================================================================================================================
+    testNum = "5013"
+
+    supported_platforms = clsTestService.updatePlatforms(testNum)
+
+    status = "Fail"
+    timeout_accured = "False"
+    driver = None
+    common = None
+    # Test variables
+
+    typeTest            = "Entitlements of a Public Channel with Owner, Anonymous, Members and Contributor users"
+    instanceURL         = None
+    
+    normalUser          = "python_normal"
+    memberUser          = "python_member"
+    contributorUser     = "python_contributor"
+    userPassword        = "Kaltura1!"
+    
+    description         = "Description"
+    tags                = "Tags,"
+    entryName           = None
+    entryDescription    = "Public Entry Description"
+    entryTags           = "public,"
+    
+    channelName         = None
+    channelDescription  = "Public Channel Description"
+    channelTags         = "public,"
+
+    # Variables used in order to create a video entry with Slides and Captions
+    filePathVideo = localSettings.LOCAL_SETTINGS_MEDIA_PATH + r'\videos\QR_30_sec_new.mp4'    
+    #run test as different instances on all the supported platforms
+    @pytest.fixture(scope='module',params=supported_platforms)
+    def driverFix(self,request):
+        return request.param
+
+    def test_01(self,driverFix,env):
+        #write to log we started the test
+        logStartTest(self,driverFix)
+        try:
+            ########################### TEST SETUP ###########################
+            #capture test start time
+            self.startTime = time.time()
+            #initialize all the basic vars and start playing
+            self,self.driver = clsTestService.initializeAndLoginAsUser(self, driverFix)
+            self.common = Common(self.driver)
+            # Variables used in order to proper create the Entry
+            self.entryName             = clsTestService.addGuidToString("Entitlements - Public Channel Anonymous OFF", self.testNum)
+            self.channelName           = clsTestService.addGuidToString("Public Channel Anonymous OFF", self.testNum)
+            self.instanceUrl = self.common.base.driver.current_url
+            self.common.admin.allowAnonymous(False)
+            self.common.base.navigate(self.instanceUrl)
+            ##################### TEST STEPS - MAIN FLOW #####################
+            writeToLog("INFO","Step 1: Going to create " + self.channelName + " channel as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+            if self.common.channel.createChannel(self.channelName, self.channelDescription, self.channelTags, enums.ChannelPrivacyType.PUBLIC, True, True, True) == False:
+                writeToLog("INFO","Step 1: FAILED to create " + self.channelName + " channel as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+                return
+              
+            writeToLog("INFO","Step 2: Going to add " + self.memberUser + " as member of " + self.channelName)
+            if self.common.channel.addMembersToChannel(self.channelName, self.memberUser, enums.ChannelMemberPermission.MEMBER) == False:
+                writeToLog("INFO","Step 2: FAILED to add " + self.memberUser + " as member of " + self.channelName)
+                return
+            
+            writeToLog("INFO","Step 3: Going to add " + self.contributorUser + " as member of " + self.channelName)
+            if self.common.channel.addMembersToChannel(self.channelName, self.contributorUser, enums.ChannelMemberPermission.CONTRIBUTOR) == False:
+                writeToLog("INFO","Step 3: FAILED to add " + self.contributorUser + " as member of " + self.channelName)
+                return
+                
+            writeToLog("INFO","Step 4: Going to upload " + self.entryName + " entry as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+            if self.common.upload.uploadEntry(self.filePathVideo, self.entryName, self.entryDescription, self.entryTags, disclaimer=False) == None:
+                writeToLog("INFO","Step 4: FAILED to upload " + self.entryName + " entry as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+                return
+        
+            writeToLog("INFO","Step 5: Going to publish the " + self.entryName + " to the " + self.channelName)
+            if self.common.myMedia.publishSingleEntry(self.entryName, "", self.channelName) == False:
+                writeToLog("INFO","Step 5: FAILED to publish the " + self.entryName + " to the " + self.channelName)
+                return
+                          
+            writeToLog("INFO","Step 6: Going to navigate as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME + " to the " + self.channelName + " channel from Channels Page and access the Add To Channel Tab")
+            if self.common.channel.navigateToAddToChannel(self.channelName, enums.Location.MY_CHANNELS_PAGE) == False:
+                writeToLog("INFO","Step 6: FAILED to navigate as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME + " to the " + self.channelName + " channel from Channels Page and access the Add To Channel Tab")
+                return
+            
+            writeToLog("INFO","Step 7: Going to move to Anonymous user")
+            if self.common.login.logOutOfKMS(allowAnonymous=False) == False:
+                writeToLog("INFO","Step 7: FAILED to move to Anonymous user")
+                return
+            
+            writeToLog("INFO","Step 8: Going to verify that Anonymous user is unable to access Channels Page")
+            if self.common.channel.navigateToChannels() == True:
+                writeToLog("INFO","Step 8: FAILED, Anonymous User was able to access the Channel Page, although he shouldn't be able")
+                return
+             
+            writeToLog("INFO","Step 9: Going to authenticate with , " + self.normalUser + " normal KMS user")
+            if self.common.login.loginToKMS(self.normalUser, self.userPassword) == False:
+                writeToLog("INFO","Step 9: FAILED to authenticate with , " + self.normalUser + " normal KMS user")
+                return
+             
+            writeToLog("INFO","Step 10: Going to verify that Normal user " + self.normalUser + "  is able to access " + self.channelName + " and enter in " + self.entryName)
+            if self.common.channel.navigateToEntryFromChannel(self.channelName, self.entryName, enums.Location.CHANNELS_PAGE) == False:
+                writeToLog("INFO","Step 10: FAILED Normal user " + self.normalUser + "  was unable to access " + self.channelName + " and access the " + self.entryName)
+                return
+            
+            writeToLog("INFO","Step 11: Going to verify that the Normal user " + self.normalUser + " is unable to access the 'Add Media Tab' from" + self.channelName)
+            if self.common.channel.navigateToAddToChannel(self.channelName, enums.Location.CHANNELS_PAGE) == True:
+                writeToLog("INFO","Step 11: FAILED the Normal user " + self.normalUser + " was able to access the 'Add Media Tab' from" + self.channelName)
+                return
+            
+            writeToLog("INFO","Step 12: Going to log out from " + self.normalUser)
+            if self.common.login.logOutOfKMS(allowAnonymous=False)  == False:
+                writeToLog("INFO","Step 12: FAILED to log out from " + self.normalUser)
+                return
+            
+            writeToLog("INFO","Step 13: Going to authenticate with , " + self.memberUser + " member KMS user")
+            if self.common.login.loginToKMS(self.memberUser, self.userPassword) == False:
+                writeToLog("INFO","Step 13: FAILED to authenticate with , " + self.memberUser + " member KMS user")
+                return
+            
+            writeToLog("INFO","Step 14: Going to verify that Member user " + self.memberUser + "  is able to access " + self.channelName + " and enter in " + self.entryName)
+            if self.common.channel.navigateToEntryFromChannel(self.channelName, self.entryName, enums.Location.CHANNELS_PAGE) == False:
+                writeToLog("INFO","Step 14: FAILED to verify that Member user " + self.memberUser + "  is able to access " + self.channelName + " and enter in " + self.entryName)
+                return
+            
+            writeToLog("INFO","Step 15: Going to verify that the Member user " + self.memberUser + " is unable to access the 'Add Media Tab' for" + self.channelName)
+            if self.common.channel.navigateToAddToChannel(self.channelName, enums.Location.CHANNELS_PAGE) == True:
+                writeToLog("INFO","Step 15: FAILED the Member user " + self.memberUser + " was able to access the 'Add Media Tab' for" + self.channelName)
+                return
+            
+            writeToLog("INFO","Step 16: Going to log out from " + self.memberUser)
+            if self.common.login.logOutOfKMS(allowAnonymous=False)  == False:
+                writeToLog("INFO","Step 16: FAILED to log out from " + self.memberUser)
+                return
+            
+            writeToLog("INFO","Step 17: Going to authenticate with , " + self.contributorUser + " normal KMS user")
+            if self.common.login.loginToKMS(self.contributorUser, self.userPassword) == False:
+                writeToLog("INFO","Step 17: FAILED to authenticate with , " + self.contributorUser + " normal KMS user")
+                return
+            
+            writeToLog("INFO","Step 18: Going to verify that Contributor user " + self.contributorUser + "  is able to access " + self.channelName + " and enter in " + self.entryName)
+            if self.common.channel.navigateToEntryFromChannel(self.channelName, self.entryName, enums.Location.CHANNELS_PAGE) == False:
+                writeToLog("INFO","Step 18: FAILED to verify that Contributor user " + self.contributorUser + "  is able to access " + self.channelName + " and enter in " + self.entryName)
+                return
+            
+            writeToLog("INFO","Step 19: Going to verify that Contributor user " + self.contributorUser + "  is able to access the 'Add Media Tab' for" + self.channelName)
+            if self.common.channel.navigateToAddToChannel(self.channelName, enums.Location.CHANNELS_PAGE) == False:
+                writeToLog("INFO","Step 19: FAILED the " + self.contributorUser + "  was unable to access the 'Add Media Tab' for " + self.channelName)
+                return
+            ##################################################################
+            self.status="Pass"
+            writeToLog("INFO","TEST PASSED: " + self.typeTest)
+        # if an exception happened we need to handle it and fail the test
+        except Exception as inst:
+            self.status = clsTestService.handleException(self,inst,self.startTime)
+    ########################### TEST TEARDOWN ###########################
+    def teardown_method(self,method):
+        try:
+            self.common.handleTestFail(self.status)
+            writeToLog("INFO","**************** Starting: teardown_method ****************")
+            self.common.admin.allowAnonymous(True)
+            self.common.login.logOutOfKMS()
+            self.common.login.loginToKMS(localSettings.LOCAL_SETTINGS_LOGIN_USERNAME, localSettings.LOCAL_SETTINGS_LOGIN_PASSWORD)
+            self.common.myMedia.deleteEntriesFromMyMedia(self.entryName)
+            self.common.channel.deleteChannel(self.channelName)
+            writeToLog("INFO","**************** Ended: teardown_method *******************")
+        except:
+            pass
+        clsTestService.basicTearDown(self)
+        #write to log we finished the test
+        logFinishedTest(self,self.startTime)
+        assert (self.status == "Pass")
+
+    pytest.main('test_' + testNum  + '.py --tb=line')

--- a/web/tests/entitlements/test_5022.py
+++ b/web/tests/entitlements/test_5022.py
@@ -1,0 +1,162 @@
+import time, pytest
+import sys,os
+sys.path.insert(1,os.path.abspath(os.path.join(os.path.dirname( __file__ ),'..','..','lib')))
+from clsCommon import Common
+import clsTestService
+from localSettings import *
+import localSettings
+from utilityTestFunc import *
+import enums
+import collections
+
+
+class Test:
+
+    #================================================================================================================================
+    #  @Author: Horia Cus
+    # Test Name : Entitlements - Entry Private with Initial Owner and Changed Owner
+    # Test description:
+    # 1. Verify that the media owner its able to access the entry via media page
+    # 2. Verify that the media owner of an entry can be changed
+    # 3. Verify that the initial media owner can receive co-publisher rights
+    #================================================================================================================================
+    testNum = "5022"
+
+    supported_platforms = clsTestService.updatePlatforms(testNum)
+
+    status = "Pass"
+    timeout_accured = "False"
+    driver = None
+    common = None
+    # Test variables
+
+    typeTest            = "Initial Entry Owner changed to Co Publisher"
+    newMediaOwner       = "python_normal"
+    newMediaOwnerPass   = "Kaltura1!"
+    
+    description         = "Description"
+    tags                = "Tags,"
+    entryName           = None
+    entryDescription    = "description"
+    entryTags           = "tag1,"
+
+    # Variables used in order to create a video entry with Slides and Captions
+    filePathVideo = localSettings.LOCAL_SETTINGS_MEDIA_PATH + r'\videos\QR_30_sec_new.mp4'    
+    #run test as different instances on all the supported platforms
+    @pytest.fixture(scope='module',params=supported_platforms)
+    def driverFix(self,request):
+        return request.param
+
+    def test_01(self,driverFix,env):
+        #write to log we started the test
+        logStartTest(self,driverFix)
+        try:
+            ########################### TEST SETUP ###########################
+            #capture test start time
+            self.startTime = time.time()
+            #initialize all the basic vars and start playing
+            self,self.driver = clsTestService.initializeAndLoginAsUser(self, driverFix)
+            self.common = Common(self.driver)
+            # Variables used in order to proper create the Entry
+            self.entryName             = clsTestService.addGuidToString("Entitlements - Owner user changed to Co Publisher", self.testNum)
+            ##################### TEST STEPS - MAIN FLOW #####################
+            writeToLog("INFO","Step 1: Going to upload " + self.entryName + " entry as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+            if self.common.upload.uploadEntry(self.filePathVideo, self.entryName, self.entryDescription, self.entryTags, disclaimer=False) == None:
+                self.status = "Fail"
+                writeToLog("INFO","Step 1: FAILED to upload " + self.entryName + " entry as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+                return
+     
+            writeToLog("INFO","Step 2: Going to navigate to the entry page for " + self.entryName + " entry as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+            if self.common.entryPage.navigateToEntryPageFromMyMedia(self.entryName) == False:
+                self.status = "Fail"
+                writeToLog("INFO","Step 2: FAILED to navigate to the entry page for " + self.entryName + " entry as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+                return
+            
+            writeToLog("INFO","Step 3: Going to navigate to the Edit Entry Page for " + self.entryName)
+            if self.common.editEntryPage.navigateToEditEntryPageFromEntryPage(self.entryName) == False:
+                self.status = "Fail"
+                writeToLog("INFO","Step 3: FAILED to navigate to the entry page for " + self.entryName)
+                return
+            
+            writeToLog("INFO","Step 4: Going to change the owner of " + self.entryName + " entry as " + self.newMediaOwner)
+            if self.common.editEntryPage.changeMediaOwner(self.newMediaOwner) == False:
+                self.status = "Fail"
+                writeToLog("INFO","Step 4: FAILED to change the owner of " + self.entryName + " entry as " + self.newMediaOwner)
+                return
+            
+            writeToLog("INFO","Step 5: Going to log out from " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+            if self.common.login.logOutOfKMS() == False:
+                self.status = "Fail"
+                writeToLog("INFO","Step 5: FAILED to log out from " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+                return
+            
+            writeToLog("INFO","Step 6: Going to authenticate using " + self.newMediaOwner)
+            if self.common.login.loginToKMS(self.newMediaOwner, self.newMediaOwnerPass) == False:
+                self.status = "Fail"
+                writeToLog("INFO","Step 6: FAILED to authenticate using " + self.newMediaOwner)
+                return
+            
+            writeToLog("INFO","Step 7: Going to navigate to the entry page of " + self.entryName + " entry as " + self.newMediaOwner)
+            if self.common.entryPage.navigateToEntryPageFromMyMedia(self.entryName) == False:
+                self.status = "Fail"
+                writeToLog("INFO","Step 7: FAILED to navigate to the entry page of " + self.entryName + " entry as " + self.newMediaOwner)
+                return
+            
+            writeToLog("INFO","Step 8: Going to navigate to the Edit Entry Page of " + self.entryName + " entry as " + self.newMediaOwner)
+            if self.common.editEntryPage.navigateToEditEntryPageFromEntryPage(self.entryName) == False:
+                writeToLog("INFO","Step 8: FAILED to navigate to the entry page of " + self.entryName + " entry as " + self.newMediaOwner)
+                return
+            
+            writeToLog("INFO","Step 9: Going to add " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME + " as Co Publisher of " + self.entryName + " entry ")
+            if self.common.editEntryPage.addCollaborator(self.entryName, localSettings.LOCAL_SETTINGS_LOGIN_USERNAME, False, True) == False:
+                writeToLog("INFO","Step 9: FAILED to add " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME + " as Co Publisher of " + self.entryName + " entry ")
+                return
+            
+            writeToLog("INFO","Step 10: Going to log out from " + self.newMediaOwner)
+            if self.common.login.logOutOfKMS() == False:
+                self.status = "Fail"
+                writeToLog("INFO","Step 10: FAILED to log out from " + self.newMediaOwner)
+                return
+            
+            writeToLog("INFO","Step 11: Going to authenticate using " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+            if self.common.login.loginToKMS(localSettings.LOCAL_SETTINGS_LOGIN_USERNAME, localSettings.LOCAL_SETTINGS_LOGIN_PASSWORD) == False:
+                self.status = "Fail"
+                writeToLog("INFO","Step 11: FAILED to authenticate using " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+                return
+            
+            writeToLog("INFO","Step 12: Going to navigate to the entry page for " + self.entryName + " entry as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME + " while having Co Publisher rights")
+            if self.common.entryPage.navigateToEntryPageFromMyMedia(self.entryName) == False:
+                self.common.myMedia.clearSearch()
+                sleep(1)            
+                if self.common.myMedia.searchEntryMyMedia(self.entryName, forceNavigate=False) == False:
+                    self.status = "Fail"
+                    writeToLog("INFO","Step 12.1: FAILED to navigate to the entry page for " + self.entryName + " entry as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+                    return 
+                sleep(2)
+                if self.common.myMedia.clickEntryAfterSearchInMyMedia(self.entryName) == False:
+                    self.status = "Fail"
+                    writeToLog("INFO","Step 12.2: FAILED to navigate to the entry page for " + self.entryName + " entry as " +localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+                    return                
+                sleep(5)
+            ##################################################################
+            writeToLog("INFO","TEST PASSED: Entry Page has been successfully verified for a " + self.typeTest)
+        # if an exception happened we need to handle it and fail the test
+        except Exception as inst:
+            self.status = clsTestService.handleException(self,inst,self.startTime)
+    ########################### TEST TEARDOWN ###########################
+    def teardown_method(self,method):
+        try:
+            self.common.handleTestFail(self.status)
+            writeToLog("INFO","**************** Starting: teardown_method ****************")
+            self.common.login.logOutOfKMS()
+            self.common.login.loginToKMS(self.newMediaOwner, self.newMediaOwnerPass)
+            self.common.myMedia.deleteEntriesFromMyMedia(self.entryName)
+            writeToLog("INFO","**************** Ended: teardown_method *******************")
+        except:
+            pass
+        clsTestService.basicTearDown(self)
+        #write to log we finished the test
+        logFinishedTest(self,self.startTime)
+        assert (self.status == "Pass")
+
+    pytest.main('test_' + testNum  + '.py --tb=line')

--- a/web/tests/entitlements/test_5024.py
+++ b/web/tests/entitlements/test_5024.py
@@ -1,0 +1,187 @@
+import time, pytest
+import sys,os
+sys.path.insert(1,os.path.abspath(os.path.join(os.path.dirname( __file__ ),'..','..','lib')))
+from clsCommon import Common
+import clsTestService
+from localSettings import *
+import localSettings
+from utilityTestFunc import *
+import enums
+import collections
+
+
+class Test:
+
+    #================================================================================================================================
+    #  @Author: Horia Cus
+    # Test Name : Entitlements - Private Channel using Global Page
+    # Test description:
+    # 1. Create a Private Channel
+    # 2. Publish an entry inside the Private Channel
+    # 3. Add a member and a contributor to the private channel
+    # 4. Verify that the Channel owner its able to find the private channel using Global Search
+    # 5. Verify that the Anonymous user and KMS User are unable to find the Private Channel and entry inside the global search results
+    # 6. Verify that the Channel and Contributor members are able to find the Private Channel and entry inside the global search results
+    #================================================================================================================================
+    testNum = "5024"
+
+    supported_platforms = clsTestService.updatePlatforms(testNum)
+
+    status = "Fail"
+    timeout_accured = "False"
+    driver = None
+    common = None
+    # Test variables
+
+    typeTest            = "Entitlements of a Private Channel with Owner, Anonymous, Members and Contributor users"
+    
+    anonymousUser       = "Anonymous User"
+    normalUser          = "python_normal"
+    memberUser          = "python_member"
+    contributorUser     = "python_contributor"
+    userPassword        = "Kaltura1!"
+    
+    description         = "Description"
+    tags                = "Tags,"
+    entryName           = None
+    entryDescription    = "Private Entry Description"
+    entryTags           = "private,"
+    
+    channelName         = None
+    channelDescription  = "Private Channel Description"
+    channelTags         = "private,"
+
+    # Variables used in order to create a video entry with Slides and Captions
+    filePathVideo = localSettings.LOCAL_SETTINGS_MEDIA_PATH + r'\videos\QR_30_sec_new.mp4'    
+    #run test as different instances on all the supported platforms
+    @pytest.fixture(scope='module',params=supported_platforms)
+    def driverFix(self,request):
+        return request.param
+
+    def test_01(self,driverFix,env):
+        #write to log we started the test
+        logStartTest(self,driverFix)
+        try:
+            ########################### TEST SETUP ###########################
+            #capture test start time
+            self.startTime = time.time()
+            #initialize all the basic vars and start playing
+            self,self.driver = clsTestService.initializeAndLoginAsUser(self, driverFix)
+            self.common = Common(self.driver)
+            # Variables used in order to proper create the Entry
+            self.entryName             = clsTestService.addGuidToString("Entitlements - Private Channel", self.testNum)
+            self.channelName           = clsTestService.addGuidToString("Private Channel", self.testNum)
+            ##################### TEST STEPS - MAIN FLOW #####################
+            writeToLog("INFO","Step 1: Going to create " + self.channelName + " channel as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+            if self.common.channel.createChannel(self.channelName, self.channelDescription, self.channelTags, enums.ChannelPrivacyType.PRIVATE, True, True, True) == False:
+                writeToLog("INFO","Step 1: FAILED to create " + self.channelName + " channel as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+                return
+               
+            writeToLog("INFO","Step 2: Going to add " + self.memberUser + " as member of " + self.channelName)
+            if self.common.channel.addMembersToChannel(self.channelName, self.memberUser, enums.ChannelMemberPermission.MEMBER) == False:
+                writeToLog("INFO","Step 2: FAILED to add " + self.memberUser + " as member of " + self.channelName)
+                return
+              
+            writeToLog("INFO","Step 3: Going to add " + self.contributorUser + " as contributor of " + self.channelName)
+            if self.common.channel.addMembersToChannel(self.channelName, self.contributorUser, enums.ChannelMemberPermission.CONTRIBUTOR) == False:
+                writeToLog("INFO","Step 3: FAILED to add " + self.contributorUser + " as contributor of " + self.channelName)
+                return
+    
+            writeToLog("INFO","Step 4: Going to upload " + self.entryName + " entry as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+            if self.common.upload.uploadEntry(self.filePathVideo, self.entryName, self.entryDescription, self.entryTags, disclaimer=False) == None:
+                writeToLog("INFO","Step 4: FAILED to upload " + self.entryName + " entry as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+                return
+         
+            writeToLog("INFO","Step 5: Going to publish the " + self.entryName + " to the " + self.channelName)
+            if self.common.myMedia.publishSingleEntry(self.entryName, "", self.channelName) == False:
+                writeToLog("INFO","Step 5: FAILED to publish the " + self.entryName + " to the " + self.channelName)
+                return
+                          
+            writeToLog("INFO","Step 6: Going to verify that for the " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME + ", the " + self.channelName + " channel is displayed in global search")
+            if self.common.globalSearch.serchAndVerifyChannelInGlobalSearch(self.channelName) == False:
+                writeToLog("INFO","Step 6: FAILED, the "+ self.channelName + " channel hasn't been found in the global search results while it should")
+                return
+             
+            writeToLog("INFO","Step 7: Going to move to Anonymous user")
+            if self.common.login.logOutOfKMS() == False:
+                writeToLog("INFO","Step 7: FAILED to move to Anonymous user")
+                return
+            
+            writeToLog("INFO","Step 8: Going to verify that for the " + self.anonymousUser + ", the " + self.channelName + " channel is not displayed in global search")
+            if self.common.globalSearch.serchAndVerifyChannelInGlobalSearch(self.channelName) != False:
+                writeToLog("INFO","Step 8: FAILED, the "+ self.channelName + " channel has been displayed in the global search results while it shouldn't")
+                return
+             
+            writeToLog("INFO","Step 9: Going to verify that for the " + self.anonymousUser + " , the " + self.entryName + " entry is not displayed in global search")
+            if self.common.globalSearch.serchAndVerifyEntryInGlobalSearch(self.entryName) != False:
+                writeToLog("INFO","Step 9: FAILED, the "+ self.entryName + " entry has been displayed in the global search results while it shouldn't")
+                return  
+             
+            writeToLog("INFO","Step 10: Going to authenticate with , " + self.normalUser + " normal KMS user")
+            if self.common.login.loginToKMS(self.normalUser, self.userPassword) == False:
+                writeToLog("INFO","Step 10: FAILED to authenticate with , " + self.normalUser + " normal KMS user")
+                return
+             
+            writeToLog("INFO","Step 11: Going to verify that for the " + self.normalUser + ", the " + self.channelName + " channel is not displayed in global search")
+            if self.common.globalSearch.serchAndVerifyChannelInGlobalSearch(self.channelName) != False:
+                writeToLog("INFO","Step 11: FAILED, the "+ self.channelName + " channel has been displayed in the global search results while it shouldn't")
+                return
+             
+            writeToLog("INFO","Step 12: Going to verify that for the " + self.normalUser + " , the " + self.entryName + " entry is not displayed in global search")
+            if self.common.globalSearch.serchAndVerifyEntryInGlobalSearch(self.entryName) != False:
+                writeToLog("INFO","Step 12: FAILED, the "+ self.entryName + " entry has been displayed in the global search results while it shouldn't")
+                return  
+            
+            writeToLog("INFO","Step 13: Going to log out from " + self.normalUser + " and authenticate with " + self.memberUser)
+            if self.common.login.logOutThenLogInToKMS(self.memberUser, self.userPassword) == False:
+                writeToLog("INFO","Step 13: FAILED to log out from " + self.normalUser + " and authenticate with " + self.memberUser)
+                return
+            
+            writeToLog("INFO","Step 14: Going to verify that for the " + self.memberUser + ", the " + self.channelName + " channel is  displayed in global search")
+            if self.common.globalSearch.serchAndVerifyChannelInGlobalSearch(self.channelName) == False:
+                writeToLog("INFO","Step 14: FAILED, the "+ self.channelName + " channel hasn't been found in the global search results while it should")
+                return
+             
+            writeToLog("INFO","Step 15: Going to verify that for the " + self.memberUser + " , the " + self.entryName + " entry is displayed in global search")
+            if self.common.globalSearch.serchAndVerifyEntryInGlobalSearch(self.entryName) == False:
+                writeToLog("INFO","Step 15: FAILED, the "+ self.entryName + " entry hasn't been found displayed in in the global search results while it should")
+                return  
+            
+            writeToLog("INFO","Step 16: Going to log out from " + self.memberUser + " and authenticate with " + self.contributorUser)
+            if self.common.login.logOutThenLogInToKMS(self.contributorUser, self.userPassword) == False:
+                writeToLog("INFO","Step 16: FAILED to log out from " + self.memberUser + " and authenticate with " + self.contributorUser)
+                return
+            
+            writeToLog("INFO","Step 17: Going to verify that for the " + self.contributorUser + ", the " + self.channelName + " channel is displayed in global search")
+            if self.common.globalSearch.serchAndVerifyChannelInGlobalSearch(self.channelName) == False:
+                writeToLog("INFO","Step 17: FAILED, the "+ self.channelName + " channel hasn't been found in the global search results while it should")
+                return
+             
+            writeToLog("INFO","Step 18: Going to verify that for the " + self.contributorUser + " , the " + self.entryName + " entry is displayed in global search")
+            if self.common.globalSearch.serchAndVerifyEntryInGlobalSearch(self.entryName) == False:
+                writeToLog("INFO","Step 18: FAILED, the "+ self.entryName + " entry hasn't been found displayed in in the global search results while it should")
+                return  
+            ##################################################################
+            self.status="Pass"
+            writeToLog("INFO","TEST PASSED: " + self.typeTest)
+        # if an exception happened we need to handle it and fail the test
+        except Exception as inst:
+            self.status = clsTestService.handleException(self,inst,self.startTime)
+    ########################### TEST TEARDOWN ###########################
+    def teardown_method(self,method):
+        try:
+            self.common.handleTestFail(self.status)
+            writeToLog("INFO","**************** Starting: teardown_method ****************")
+            self.common.login.logOutOfKMS()
+            self.common.login.loginToKMS(localSettings.LOCAL_SETTINGS_LOGIN_USERNAME, localSettings.LOCAL_SETTINGS_LOGIN_PASSWORD)
+            self.common.myMedia.deleteEntriesFromMyMedia(self.entryName)
+            self.common.channel.deleteChannel(self.channelName)
+            writeToLog("INFO","**************** Ended: teardown_method *******************")
+        except:
+            pass
+        clsTestService.basicTearDown(self)
+        #write to log we finished the test
+        logFinishedTest(self,self.startTime)
+        assert (self.status == "Pass")
+
+    pytest.main('test_' + testNum  + '.py --tb=line')

--- a/web/tests/entitlements/test_5025.py
+++ b/web/tests/entitlements/test_5025.py
@@ -1,0 +1,166 @@
+import time, pytest
+import sys,os
+sys.path.insert(1,os.path.abspath(os.path.join(os.path.dirname( __file__ ),'..','..','lib')))
+from clsCommon import Common
+import clsTestService
+from localSettings import *
+import localSettings
+from utilityTestFunc import *
+import enums
+import collections
+
+
+class Test:
+
+    #================================================================================================================================
+    #  @Author: Horia Cus
+    # Test Name : Entitlements - Open Channel using Global Page 
+    # Test description:
+    # 1. Create an Open Channel
+    # 2. Publish an entry inside the Open Channel
+    # 3. Add a member to the Open channel
+    # 4. Verify that the Channel owner its able to find the private channel inside global search results
+    # 5. Verify that the Anonymous user is unable to find the private channel and entry inside the global search results
+    # 6. Verify that Normal KMS users is able to find the private channel and entry inside the global search results
+    #================================================================================================================================
+    testNum = "5025"
+
+    supported_platforms = clsTestService.updatePlatforms(testNum)
+
+    status = "Fail"
+    timeout_accured = "False"
+    driver = None
+    common = None
+    # Test variables
+
+    typeTest            = "Entitlements for an Open Channel with Owner, Anonymous and Members users"
+    
+    anonymousUser       = "Anonymous User"
+    normalUser          = "python_normal"
+    memberUser          = "python_member"
+    userPassword        = "Kaltura1!"
+    
+    description         = "Description"
+    tags                = "Tags,"
+    entryName           = None
+    entryDescription    = "Open Entry Description"
+    entryTags           = "open,"
+    
+    channelName         = None
+    channelDescription  = "Open Channel Description"
+    channelTags         = "open,"
+
+    # Variables used in order to create a video entry with Slides and Captions
+    filePathVideo = localSettings.LOCAL_SETTINGS_MEDIA_PATH + r'\videos\QR_30_sec_new.mp4'    
+    #run test as different instances on all the supported platforms
+    @pytest.fixture(scope='module',params=supported_platforms)
+    def driverFix(self,request):
+        return request.param
+
+    def test_01(self,driverFix,env):
+        #write to log we started the test
+        logStartTest(self,driverFix)
+        try:
+            ########################### TEST SETUP ###########################
+            #capture test start time
+            self.startTime = time.time()
+            #initialize all the basic vars and start playing
+            self,self.driver = clsTestService.initializeAndLoginAsUser(self, driverFix)
+            self.common = Common(self.driver)
+            # Variables used in order to proper create the Entry
+            self.entryName             = clsTestService.addGuidToString("Entitlements - Open Channel", self.testNum)
+            self.channelName           = clsTestService.addGuidToString("Open Channel", self.testNum)
+            ##################### TEST STEPS - MAIN FLOW #####################
+            writeToLog("INFO","Step 1: Going to create " + self.channelName + " channel as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+            if self.common.channel.createChannel(self.channelName, self.channelDescription, self.channelTags, enums.ChannelPrivacyType.OPEN, True, True, True) == False:
+                writeToLog("INFO","Step 1: FAILED to create " + self.channelName + " channel as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+                return
+              
+            writeToLog("INFO","Step 2: Going to add " + self.memberUser + " as member of " + self.channelName)
+            if self.common.channel.addMembersToChannel(self.channelName, self.memberUser, enums.ChannelMemberPermission.MEMBER) == False:
+                writeToLog("INFO","Step 2: FAILED to add " + self.memberUser + " as member of " + self.channelName)
+                return
+   
+            writeToLog("INFO","Step 3: Going to upload " + self.entryName + " entry as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+            if self.common.upload.uploadEntry(self.filePathVideo, self.entryName, self.entryDescription, self.entryTags, disclaimer=False) == None:
+                writeToLog("INFO","Step 3: FAILED to upload " + self.entryName + " entry as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+                return
+        
+            writeToLog("INFO","Step 4: Going to publish the " + self.entryName + " to the " + self.channelName)
+            if self.common.myMedia.publishSingleEntry(self.entryName, "", self.channelName) == False:
+                writeToLog("INFO","Step 4: FAILED to publish the " + self.entryName + " to the " + self.channelName)
+                return
+                          
+            writeToLog("INFO","Step 5: Going to verify that for the " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME + ", the " + self.channelName + " channel is displayed in global search")
+            if self.common.globalSearch.serchAndVerifyChannelInGlobalSearch(self.channelName) == False:
+                writeToLog("INFO","Step 5: FAILED, the " + self.channelName + " channel hasn't been found in the global search results while it should")
+                return
+             
+            writeToLog("INFO","Step 6: Going to move to Anonymous user")
+            if self.common.login.logOutOfKMS() == False:
+                writeToLog("INFO","Step 6: FAILED to move to Anonymous user")
+                return
+                          
+            writeToLog("INFO","Step 7: Going to verify that for the " + self.anonymousUser + ", the " + self.channelName + " channel is not displayed in global search")
+            if self.common.globalSearch.serchAndVerifyChannelInGlobalSearch(self.channelName) != False:
+                writeToLog("INFO","Step 7: FAILED, the "+ self.channelName + " channel has been displayed in the global search results while it shouldn't")
+                return
+             
+            writeToLog("INFO","Step 8: Going to verify that for the " + self.anonymousUser + " , the " + self.entryName + " entry is not displayed in global search")
+            if self.common.globalSearch.serchAndVerifyEntryInGlobalSearch(self.entryName) != False:
+                writeToLog("INFO","Step 8: FAILED, the "+ self.entryName + " entry has been displayed in the global search results while it shouldn't")
+                return  
+             
+            writeToLog("INFO","Step 9: Going to authenticate with , " + self.normalUser + " normal KMS user")
+            if self.common.login.loginToKMS(self.normalUser, self.userPassword) == False:
+                writeToLog("INFO","Step 9: FAILED to authenticate with , " + self.normalUser + " normal KMS user")
+                return
+              
+            writeToLog("INFO","Step 10: Going to verify that for the " + self.normalUser + ", the " + self.channelName + " channel is displayed in global search")
+            if self.common.globalSearch.serchAndVerifyChannelInGlobalSearch(self.channelName) == False:
+                writeToLog("INFO","Step 10: FAILED, the "+ self.channelName + " channel hasn't been found in the global search results while it should")
+                return
+             
+            writeToLog("INFO","Step 11: Going to verify that for the " + self.normalUser + " , the " + self.entryName + " entry is displayed in global search")
+            if self.common.globalSearch.serchAndVerifyEntryInGlobalSearch(self.entryName) == False:
+                writeToLog("INFO","Step 11: FAILED, the " + self.entryName + " entry hasn't been found displayed in in the global search results while it should")
+                return 
+            
+            writeToLog("INFO","Step 12: Going to log out from " + self.normalUser + " and authenticate with " + self.memberUser)
+            if self.common.login.logOutThenLogInToKMS(self.memberUser, self.userPassword) == False:
+                writeToLog("INFO","Step 12: FAILED to log out from " + self.normalUser + " and authenticate with " + self.memberUser)
+                return
+            
+            writeToLog("INFO","Step 13: Going to verify that for the " + self.memberUser + ", the " + self.channelName + " channel is displayed in global search")
+            if self.common.globalSearch.serchAndVerifyChannelInGlobalSearch(self.channelName) == False:
+                writeToLog("INFO","Step 13: FAILED, the " + self.channelName + " channel hasn't been found in the global search results while it should")
+                return
+             
+            writeToLog("INFO","Step 14: Going to verify that for the " + self.memberUser + " , the " + self.entryName + " entry is displayed in global search")
+            if self.common.globalSearch.serchAndVerifyEntryInGlobalSearch(self.entryName) == False:
+                writeToLog("INFO","Step 14: FAILED, the " + self.entryName + " entry hasn't been found displayed in in the global search results while it should")
+                return  
+            ##################################################################
+            self.status="Pass"
+            writeToLog("INFO","TEST PASSED: " + self.typeTest)
+        # if an exception happened we need to handle it and fail the test
+        except Exception as inst:
+            self.status = clsTestService.handleException(self,inst,self.startTime)
+    ########################### TEST TEARDOWN ###########################
+    def teardown_method(self,method):
+        try:
+            self.common.handleTestFail(self.status)
+            writeToLog("INFO","**************** Starting: teardown_method ****************")
+            self.common.login.logOutOfKMS()
+            self.common.login.loginToKMS(localSettings.LOCAL_SETTINGS_LOGIN_USERNAME, localSettings.LOCAL_SETTINGS_LOGIN_PASSWORD)
+            self.common.myMedia.deleteEntriesFromMyMedia(self.entryName)
+            self.common.channel.deleteChannel(self.channelName)
+            writeToLog("INFO","**************** Ended: teardown_method *******************")
+        except:
+            pass
+        clsTestService.basicTearDown(self)
+        #write to log we finished the test
+        logFinishedTest(self,self.startTime)
+        assert (self.status == "Pass")
+
+    pytest.main('test_' + testNum  + '.py --tb=line')

--- a/web/tests/entitlements/test_5026.py
+++ b/web/tests/entitlements/test_5026.py
@@ -1,0 +1,187 @@
+import time, pytest
+import sys,os
+sys.path.insert(1,os.path.abspath(os.path.join(os.path.dirname( __file__ ),'..','..','lib')))
+from clsCommon import Common
+import clsTestService
+from localSettings import *
+import localSettings
+from utilityTestFunc import *
+import enums
+import collections
+
+
+class Test:
+
+    #================================================================================================================================
+    #  @Author: Horia Cus
+    # Test Name : Entitlements - Restricted Channel using Channels Page 
+    # Test description:
+    # 1. Create a Restricted Channel
+    # 2. Publish an entry inside the Restricted Channel
+    # 3. Add a member and a contributor to the Restricted channel
+    # 4. Verify that the Channel owner its able to find the private channel inside the global search results
+    # 5. Verify that the Anonymous user is unable to find the private channel and entry inside the global search results
+    # 6. Verify that Logged in KMS users, Restricted Channel Members and Contributors are able to find the private channel and entry inside the global search results
+    #================================================================================================================================
+    testNum = "5026"
+
+    supported_platforms = clsTestService.updatePlatforms(testNum)
+
+    status = "Fail"
+    timeout_accured = "False"
+    driver = None
+    common = None
+    # Test variables
+
+    typeTest            = "Entitlements of a Restricted Channel with Owner, Anonymous, Members and Contributor users"
+
+    anonymousUser       = "Anonymous User"
+    normalUser          = "python_normal"
+    memberUser          = "python_member"
+    contributorUser     = "python_contributor"
+    userPassword        = "Kaltura1!"
+    
+    description         = "Description"
+    tags                = "Tags,"
+    entryName           = None
+    entryDescription    = "Restricted Entry Description"
+    entryTags           = "restricted,"
+    
+    channelName         = None
+    channelDescription  = "Restricted Channel Description"
+    channelTags         = "restricted,"
+
+    # Variables used in order to create a video entry with Slides and Captions
+    filePathVideo = localSettings.LOCAL_SETTINGS_MEDIA_PATH + r'\videos\QR_30_sec_new.mp4'    
+    #run test as different instances on all the supported platforms
+    @pytest.fixture(scope='module',params=supported_platforms)
+    def driverFix(self,request):
+        return request.param
+
+    def test_01(self,driverFix,env):
+        #write to log we started the test
+        logStartTest(self,driverFix)
+        try:
+            ########################### TEST SETUP ###########################
+            #capture test start time
+            self.startTime = time.time()
+            #initialize all the basic vars and start playing
+            self,self.driver = clsTestService.initializeAndLoginAsUser(self, driverFix)
+            self.common = Common(self.driver)
+            # Variables used in order to proper create the Entry
+            self.entryName             = clsTestService.addGuidToString("Entitlements - Restricted Channel", self.testNum)
+            self.channelName           = clsTestService.addGuidToString("Restricted Channel", self.testNum)
+            ##################### TEST STEPS - MAIN FLOW #####################
+            writeToLog("INFO","Step 1: Going to create " + self.channelName + " channel as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+            if self.common.channel.createChannel(self.channelName, self.channelDescription, self.channelTags, enums.ChannelPrivacyType.RESTRICTED, True, True, True) == False:
+                writeToLog("INFO","Step 1: FAILED to create " + self.channelName + " channel as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+                return
+              
+            writeToLog("INFO","Step 2: Going to add " + self.memberUser + " as member of " + self.channelName)
+            if self.common.channel.addMembersToChannel(self.channelName, self.memberUser, enums.ChannelMemberPermission.MEMBER) == False:
+                writeToLog("INFO","Step 2: FAILED to add " + self.memberUser + " as member of " + self.channelName)
+                return
+             
+            writeToLog("INFO","Step 3: Going to add " + self.contributorUser + " as contributor of " + self.channelName)
+            if self.common.channel.addMembersToChannel(self.channelName, self.contributorUser, enums.ChannelMemberPermission.CONTRIBUTOR) == False:
+                writeToLog("INFO","Step 3: FAILED to add " + self.contributorUser + " as contributor of " + self.channelName)
+                return
+   
+            writeToLog("INFO","Step 4: Going to upload " + self.entryName + " entry as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+            if self.common.upload.uploadEntry(self.filePathVideo, self.entryName, self.entryDescription, self.entryTags, disclaimer=False) == None:
+                writeToLog("INFO","Step 4: FAILED to upload " + self.entryName + " entry as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+                return
+        
+            writeToLog("INFO","Step 5: Going to publish the " + self.entryName + " to the " + self.channelName)
+            if self.common.myMedia.publishSingleEntry(self.entryName, "", self.channelName) == False:
+                writeToLog("INFO","Step 5: FAILED to publish the " + self.entryName + " to the " + self.channelName)
+                return
+                          
+            writeToLog("INFO","Step 6: Going to verify that for the " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME + ", the " + self.channelName + " channel is displayed in global search")
+            if self.common.globalSearch.serchAndVerifyChannelInGlobalSearch(self.channelName) == False:
+                writeToLog("INFO","Step 6: FAILED, the " + self.channelName + " channel hasn't been found in the global search results while it should")
+                return
+             
+            writeToLog("INFO","Step 7: Going to move to Anonymous user")
+            if self.common.login.logOutOfKMS() == False:
+                writeToLog("INFO","Step 7: FAILED to move to Anonymous user")
+                return
+             
+            writeToLog("INFO","Step 8: Going to verify that for the " + self.anonymousUser + ", the " + self.channelName + " channel is not displayed in global search")
+            if self.common.globalSearch.serchAndVerifyChannelInGlobalSearch(self.channelName) != False:
+                writeToLog("INFO","Step 8: FAILED, the "+ self.channelName + " channel has been displayed in the global search results while it shouldn't")
+                return
+             
+            writeToLog("INFO","Step 9: Going to verify that for the " + self.anonymousUser + " , the " + self.entryName + " entry is not displayed in global search")
+            if self.common.globalSearch.serchAndVerifyEntryInGlobalSearch(self.entryName) != False:
+                writeToLog("INFO","Step 9: FAILED, the "+ self.entryName + " entry has been displayed in the global search results while it shouldn't")
+                return  
+             
+            writeToLog("INFO","Step 10: Going to authenticate with , " + self.normalUser + " normal KMS user")
+            if self.common.login.loginToKMS(self.normalUser, self.userPassword) == False:
+                writeToLog("INFO","Step 10: FAILED to authenticate with , " + self.normalUser + " normal KMS user")
+                return
+             
+            writeToLog("INFO","Step 11: Going to verify that for the " + self.normalUser + ", the " + self.channelName + " channel is displayed in global search")
+            if self.common.globalSearch.serchAndVerifyChannelInGlobalSearch(self.channelName) == False:
+                writeToLog("INFO","Step 11: FAILED, the "+ self.channelName + " channel hasn't been found in in the global search results while it should")
+                return
+             
+            writeToLog("INFO","Step 12: Going to verify that for the " + self.normalUser + " , the " + self.entryName + " entry is displayed in global search")
+            if self.common.globalSearch.serchAndVerifyEntryInGlobalSearch(self.entryName) == False:
+                writeToLog("INFO","Step 12: FAILED, the " + self.entryName + " entry hasn't been found displayed in in the global search results while it should")
+                return 
+            
+            writeToLog("INFO","Step 13: Going to log out from " + self.normalUser + " and authenticate with " + self.memberUser)
+            if self.common.login.logOutThenLogInToKMS(self.memberUser, self.userPassword) == False:
+                writeToLog("INFO","Step 13: FAILED to log out from " + self.normalUser + " and authenticate with " + self.memberUser)
+                return
+
+            writeToLog("INFO","Step 14: Going to verify that for the " + self.memberUser + ", the " + self.channelName + " channel is displayed in global search")
+            if self.common.globalSearch.serchAndVerifyChannelInGlobalSearch(self.channelName) == False:
+                writeToLog("INFO","Step 14: FAILED, the "+ self.channelName + " channel hasn't been found in in the global search results while it should")
+                return
+             
+            writeToLog("INFO","Step 15: Going to verify that for the " + self.memberUser + " , the " + self.entryName + " entry is displayed in global search")
+            if self.common.globalSearch.serchAndVerifyEntryInGlobalSearch(self.entryName) == False:
+                writeToLog("INFO","Step 15: FAILED, the " + self.entryName + " entry hasn't been found displayed in in the global search results while it should")
+                return 
+            
+            writeToLog("INFO","Step 16: Going to log out from " + self.memberUser + " and authenticate with " + self.contributorUser)
+            if self.common.login.logOutThenLogInToKMS(self.contributorUser, self.userPassword) == False:
+                writeToLog("INFO","Step 16: FAILED to log out from " + self.memberUser + " and authenticate with " + self.contributorUser)
+                return
+            
+            writeToLog("INFO","Step 17: Going to verify that for the " + self.contributorUser + ", the " + self.channelName + " channel is displayed in global search")
+            if self.common.globalSearch.serchAndVerifyChannelInGlobalSearch(self.channelName) == False:
+                writeToLog("INFO","Step 17: FAILED, the "+ self.channelName + " channel hasn't been found in in the global search results while it should")
+                return
+             
+            writeToLog("INFO","Step 18: Going to verify that for the " + self.contributorUser + " , the " + self.entryName + " entry is displayed in global search")
+            if self.common.globalSearch.serchAndVerifyEntryInGlobalSearch(self.entryName) == False:
+                writeToLog("INFO","Step 18: FAILED, the " + self.entryName + " entry hasn't been found displayed in in the global search results while it should")
+                return 
+            ##################################################################
+            self.status="Pass"
+            writeToLog("INFO","TEST PASSED: " + self.typeTest)
+        # if an exception happened we need to handle it and fail the test
+        except Exception as inst:
+            self.status = clsTestService.handleException(self,inst,self.startTime)
+    ########################### TEST TEARDOWN ###########################
+    def teardown_method(self,method):
+        try:
+            self.common.handleTestFail(self.status)
+            writeToLog("INFO","**************** Starting: teardown_method ****************")
+            self.common.login.logOutOfKMS()
+            self.common.login.loginToKMS(localSettings.LOCAL_SETTINGS_LOGIN_USERNAME, localSettings.LOCAL_SETTINGS_LOGIN_PASSWORD)
+            self.common.myMedia.deleteEntriesFromMyMedia(self.entryName)
+            self.common.channel.deleteChannel(self.channelName)
+            writeToLog("INFO","**************** Ended: teardown_method *******************")
+        except:
+            pass
+        clsTestService.basicTearDown(self)
+        #write to log we finished the test
+        logFinishedTest(self,self.startTime)
+        assert (self.status == "Pass")
+
+    pytest.main('test_' + testNum  + '.py --tb=line')

--- a/web/tests/entitlements/test_5027.py
+++ b/web/tests/entitlements/test_5027.py
@@ -1,0 +1,187 @@
+import time, pytest
+import sys,os
+sys.path.insert(1,os.path.abspath(os.path.join(os.path.dirname( __file__ ),'..','..','lib')))
+from clsCommon import Common
+import clsTestService
+from localSettings import *
+import localSettings
+from utilityTestFunc import *
+import enums
+import collections
+
+
+class Test:
+
+    #================================================================================================================================
+    #  @Author: Horia Cus
+    # Test Name : Entitlements - Shared Repository Channel using Global Page 
+    # Test description:
+    # 1. Create a Shared Repository Channel
+    # 2. Publish an entry inside the Shared Repository Channel
+    # 3. Add a member and a contributor to the Shared Repository channel
+    # 4. Verify that the Channel owner its able to find the channel inside the global page
+    # 5. Verify that the Anonymous user and KMS User are unable to find the channel and entry in global page
+    # 6. Verify that the Channel Member and Contributer are able to find the channel and entry in global page
+    #================================================================================================================================
+    testNum = "5027"
+
+    supported_platforms = clsTestService.updatePlatforms(testNum)
+
+    status = "Fail"
+    timeout_accured = "False"
+    driver = None
+    common = None
+    # Test variables
+
+    typeTest            = "Entitlements of a Shared Repository Channel with Owner, Anonymous, Members and Contributor users"
+    
+    anonymousUser       = "Anonymous User"
+    normalUser          = "python_normal"
+    memberUser          = "python_member"
+    contributorUser     = "python_contributor"
+    userPassword        = "Kaltura1!"
+    
+    description         = "Description"
+    tags                = "Tags,"
+    entryName           = None
+    entryDescription    = "Shared Entry Description"
+    entryTags           = "shared,"
+    
+    channelName         = None
+    channelDescription  = "Shared Repository Channel Description"
+    channelTags         = "shared,"
+
+    # Variables used in order to create a video entry with Slides and Captions
+    filePathVideo = localSettings.LOCAL_SETTINGS_MEDIA_PATH + r'\videos\QR_30_sec_new.mp4'    
+    #run test as different instances on all the supported platforms
+    @pytest.fixture(scope='module',params=supported_platforms)
+    def driverFix(self,request):
+        return request.param
+
+    def test_01(self,driverFix,env):
+        #write to log we started the test
+        logStartTest(self,driverFix)
+        try:
+            ########################### TEST SETUP ###########################
+            #capture test start time
+            self.startTime = time.time()
+            #initialize all the basic vars and start playing
+            self,self.driver = clsTestService.initializeAndLoginAsUser(self, driverFix)
+            self.common = Common(self.driver)
+            # Variables used in order to proper create the Entry
+            self.entryName             = clsTestService.addGuidToString("Entitlements - Shared Repository Channel", self.testNum)
+            self.channelName           = clsTestService.addGuidToString("Shared Repository Channel", self.testNum)
+            ##################### TEST STEPS - MAIN FLOW #####################
+            writeToLog("INFO","Step 1: Going to create " + self.channelName + " channel as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+            if self.common.channel.createChannel(self.channelName, self.channelDescription, self.channelTags, enums.ChannelPrivacyType.SHAREDREPOSITORY, True, True, True) == False:
+                writeToLog("INFO","Step 1: FAILED to create " + self.channelName + " channel as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+                return
+              
+            writeToLog("INFO","Step 2: Going to add " + self.memberUser + " as member of " + self.channelName)
+            if self.common.channel.addMembersToChannel(self.channelName, self.memberUser, enums.ChannelMemberPermission.MEMBER) == False:
+                writeToLog("INFO","Step 2: FAILED to add " + self.memberUser + " as member of " + self.channelName)
+                return
+             
+            writeToLog("INFO","Step 3: Going to add " + self.contributorUser + " as contributor of " + self.channelName)
+            if self.common.channel.addMembersToChannel(self.channelName, self.contributorUser, enums.ChannelMemberPermission.CONTRIBUTOR) == False:
+                writeToLog("INFO","Step 3: FAILED to add " + self.contributorUser + " as contributor of " + self.channelName)
+                return
+   
+            writeToLog("INFO","Step 4: Going to upload " + self.entryName + " entry as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+            if self.common.upload.uploadEntry(self.filePathVideo, self.entryName, self.entryDescription, self.entryTags, disclaimer=False) == None:
+                writeToLog("INFO","Step 4: FAILED to upload " + self.entryName + " entry as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+                return
+        
+            writeToLog("INFO","Step 5: Going to publish the " + self.entryName + " to the " + self.channelName)
+            if self.common.myMedia.publishSingleEntry(self.entryName, "", self.channelName) == False:
+                writeToLog("INFO","Step 5: FAILED to publish the " + self.entryName + " to the " + self.channelName)
+                return
+                          
+            writeToLog("INFO","Step 6: Going to verify that for the " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME + ", the " + self.channelName + " channel is displayed in global search")
+            if self.common.globalSearch.serchAndVerifyChannelInGlobalSearch(self.channelName) == False:
+                writeToLog("INFO","Step 6: FAILED, the " + self.channelName + " channel hasn't been found in the global search results while it should")
+                return
+             
+            writeToLog("INFO","Step 7: Going to move to Anonymous user")
+            if self.common.login.logOutOfKMS() == False:
+                writeToLog("INFO","Step 7: FAILED to move to Anonymous user")
+                return
+             
+            writeToLog("INFO","Step 8: Going to verify that for the " + self.anonymousUser + ", the " + self.channelName + " channel is not displayed in global search")
+            if self.common.globalSearch.serchAndVerifyChannelInGlobalSearch(self.channelName) != False:
+                writeToLog("INFO","Step 8: FAILED, the "+ self.channelName + " channel has been displayed in the global search results while it shouldn't")
+                return
+             
+            writeToLog("INFO","Step 9: Going to verify that for the " + self.anonymousUser + " , the " + self.entryName + " entry is not displayed in global search")
+            if self.common.globalSearch.serchAndVerifyEntryInGlobalSearch(self.entryName) != False:
+                writeToLog("INFO","Step 9: FAILED, the "+ self.entryName + " entry has been displayed in the global search results while it shouldn't")
+                return 
+             
+            writeToLog("INFO","Step 10: Going to authenticate with , " + self.normalUser + " normal KMS user")
+            if self.common.login.loginToKMS(self.normalUser, self.userPassword) == False:
+                writeToLog("INFO","Step 10: FAILED to authenticate with , " + self.normalUser + " normal KMS user")
+                return
+             
+            writeToLog("INFO","Step 11: Going to verify that for the " + self.normalUser + ", the " + self.channelName + " channel is not displayed in global search")
+            if self.common.globalSearch.serchAndVerifyChannelInGlobalSearch(self.channelName) != False:
+                writeToLog("INFO","Step 11: FAILED, the "+ self.channelName + " channel has been displayed in the global search results while it shouldn't")
+                return
+             
+            writeToLog("INFO","Step 12: Going to verify that for the " + self.normalUser + " , the " + self.entryName + " entry is not displayed in global search")
+            if self.common.globalSearch.serchAndVerifyEntryInGlobalSearch(self.entryName) != False:
+                writeToLog("INFO","Step 12: FAILED, the "+ self.entryName + " entry has been displayed in the global search results while it shouldn't")
+                return 
+            
+            writeToLog("INFO","Step 13: Going to log out from " + self.normalUser + " and authenticate with " + self.memberUser)
+            if self.common.login.logOutThenLogInToKMS(self.memberUser, self.userPassword) == False:
+                writeToLog("INFO","Step 13: FAILED to log out from " + self.normalUser + " and authenticate with " + self.memberUser)
+                return
+            
+            writeToLog("INFO","Step 14: Going to verify that for the " + self.memberUser + ", the " + self.channelName + " channel is displayed in global search")
+            if self.common.globalSearch.serchAndVerifyChannelInGlobalSearch(self.channelName) == False:
+                writeToLog("INFO","Step 14: FAILED, the "+ self.channelName + " channel hasn't been found in in the global search results while it should")
+                return
+             
+            writeToLog("INFO","Step 15: Going to verify that for the " + self.memberUser + " , the " + self.entryName + " entry is displayed in global search")
+            if self.common.globalSearch.serchAndVerifyEntryInGlobalSearch(self.entryName) == False:
+                writeToLog("INFO","Step 15: FAILED, the " + self.entryName + " entry hasn't been found displayed in in the global search results while it should")
+                return 
+            
+            writeToLog("INFO","Step 16: Going to log out from " + self.memberUser + " and authenticate with " + self.contributorUser)
+            if self.common.login.logOutThenLogInToKMS(self.contributorUser, self.userPassword) == False:
+                writeToLog("INFO","Step 16: FAILED to log out from " + self.memberUser + " and authenticate with " + self.contributorUser)
+                return
+            
+            writeToLog("INFO","Step 17: Going to verify that for the " + self.contributorUser + ", the " + self.channelName + " channel is displayed in global search")
+            if self.common.globalSearch.serchAndVerifyChannelInGlobalSearch(self.channelName) == False:
+                writeToLog("INFO","Step 17: FAILED, the "+ self.channelName + " channel hasn't been found in in the global search results while it should")
+                return
+             
+            writeToLog("INFO","Step 18: Going to verify that for the " + self.contributorUser + " , the " + self.entryName + " entry is displayed in global search")
+            if self.common.globalSearch.serchAndVerifyEntryInGlobalSearch(self.entryName) == False:
+                writeToLog("INFO","Step 18: FAILED, the " + self.entryName + " entry hasn't been found displayed in in the global search results while it should")
+                return 
+            ##################################################################
+            self.status="Pass"
+            writeToLog("INFO","TEST PASSED: " + self.typeTest)
+        # if an exception happened we need to handle it and fail the test
+        except Exception as inst:
+            self.status = clsTestService.handleException(self,inst,self.startTime)
+    ########################### TEST TEARDOWN ###########################
+    def teardown_method(self,method):
+        try:
+            self.common.handleTestFail(self.status)
+            writeToLog("INFO","**************** Starting: teardown_method ****************")
+            self.common.login.logOutOfKMS()
+            self.common.login.loginToKMS(localSettings.LOCAL_SETTINGS_LOGIN_USERNAME, localSettings.LOCAL_SETTINGS_LOGIN_PASSWORD)
+            self.common.myMedia.deleteEntriesFromMyMedia(self.entryName)
+            self.common.channel.deleteChannel(self.channelName)
+            writeToLog("INFO","**************** Ended: teardown_method *******************")
+        except:
+            pass
+        clsTestService.basicTearDown(self)
+        #write to log we finished the test
+        logFinishedTest(self,self.startTime)
+        assert (self.status == "Pass")
+
+    pytest.main('test_' + testNum  + '.py --tb=line')

--- a/web/tests/entitlements/test_5028.py
+++ b/web/tests/entitlements/test_5028.py
@@ -1,0 +1,190 @@
+import time, pytest
+import sys,os
+sys.path.insert(1,os.path.abspath(os.path.join(os.path.dirname( __file__ ),'..','..','lib')))
+from clsCommon import Common
+import clsTestService
+from localSettings import *
+import localSettings
+from utilityTestFunc import *
+import enums
+import collections
+
+
+class Test:
+
+    #================================================================================================================================
+    #  @Author: Horia Cus
+    # Test Name : Entitlements - Public Channel using Global Page and Anonymous Users ON
+    # Test description:
+    # 1. Create a Public Channel
+    # 2. Publish an entry inside the Public Channel
+    # 3. Add a member and a contributor to the Public channel
+    # 4. Verify that the Channel owner its able to find the channel inside the global page
+    # 5. Verify that the Anonymous user, KMS User, Channel Member and Contributor are able to access the channel and entry from global page
+    #================================================================================================================================
+    testNum = "5028"
+
+    supported_platforms = clsTestService.updatePlatforms(testNum)
+
+    status = "Fail"
+    timeout_accured = "False"
+    driver = None
+    common = None
+    # Test variables
+
+    typeTest            = "Entitlements of a Public Channel with Owner, Anonymous, Members and Contributor users"
+    instanceURL         = None
+    
+    anonymousUser       = "Anonymous User"
+    normalUser          = "python_normal"
+    memberUser          = "python_member"
+    contributorUser     = "python_contributor"
+    userPassword        = "Kaltura1!"
+    
+    description         = "Description"
+    tags                = "Tags,"
+    entryName           = None
+    entryDescription    = "Public Entry Description"
+    entryTags           = "public,"
+    
+    channelName         = None
+    channelDescription  = "Public Channel Description"
+    channelTags         = "public,"
+
+    # Variables used in order to create a video entry with Slides and Captions
+    filePathVideo = localSettings.LOCAL_SETTINGS_MEDIA_PATH + r'\videos\QR_30_sec_new.mp4'    
+    #run test as different instances on all the supported platforms
+    @pytest.fixture(scope='module',params=supported_platforms)
+    def driverFix(self,request):
+        return request.param
+
+    def test_01(self,driverFix,env):
+        #write to log we started the test
+        logStartTest(self,driverFix)
+        try:
+            ########################### TEST SETUP ###########################
+            #capture test start time
+            self.startTime = time.time()
+            #initialize all the basic vars and start playing
+            self,self.driver = clsTestService.initializeAndLoginAsUser(self, driverFix)
+            self.common = Common(self.driver)
+            # Variables used in order to proper create the Entry
+            self.entryName             = clsTestService.addGuidToString("Entitlements - Public Channel Anonymous ON", self.testNum)
+            self.channelName           = clsTestService.addGuidToString("Public Channel Anonymous ON", self.testNum)
+            self.instanceUrl           = self.common.base.driver.current_url
+            self.common.admin.allowAnonymous(True)
+            self.common.base.navigate(self.instanceUrl)
+            ##################### TEST STEPS - MAIN FLOW #####################
+            writeToLog("INFO","Step 1: Going to create " + self.channelName + " channel as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+            if self.common.channel.createChannel(self.channelName, self.channelDescription, self.channelTags, enums.ChannelPrivacyType.PUBLIC, True, True, True) == False:
+                writeToLog("INFO","Step 1: FAILED to create " + self.channelName + " channel as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+                return
+              
+            writeToLog("INFO","Step 2: Going to add " + self.memberUser + " as member of " + self.channelName)
+            if self.common.channel.addMembersToChannel(self.channelName, self.memberUser, enums.ChannelMemberPermission.MEMBER) == False:
+                writeToLog("INFO","Step 2: FAILED to add " + self.memberUser + " as member of " + self.channelName)
+                return
+            
+            writeToLog("INFO","Step 3: Going to add " + self.contributorUser + " as member of " + self.channelName)
+            if self.common.channel.addMembersToChannel(self.channelName, self.contributorUser, enums.ChannelMemberPermission.CONTRIBUTOR) == False:
+                writeToLog("INFO","Step 3: FAILED to add " + self.contributorUser + " as member of " + self.channelName)
+                return
+                
+            writeToLog("INFO","Step 4: Going to upload " + self.entryName + " entry as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+            if self.common.upload.uploadEntry(self.filePathVideo, self.entryName, self.entryDescription, self.entryTags, disclaimer=False) == None:
+                writeToLog("INFO","Step 4: FAILED to upload " + self.entryName + " entry as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+                return
+        
+            writeToLog("INFO","Step 5: Going to publish the " + self.entryName + " to the " + self.channelName)
+            if self.common.myMedia.publishSingleEntry(self.entryName, "", self.channelName) == False:
+                writeToLog("INFO","Step 5: FAILED to publish the " + self.entryName + " to the " + self.channelName)
+                return
+                          
+            writeToLog("INFO","Step 6: Going to verify that for the " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME + ", the " + self.channelName + " channel is displayed in global search")
+            if self.common.globalSearch.serchAndVerifyChannelInGlobalSearch(self.channelName) == False:
+                writeToLog("INFO","Step 6: FAILED, the " + self.channelName + " channel hasn't been found in the global search results while it should")
+                return
+             
+            writeToLog("INFO","Step 7: Going to move to Anonymous user")
+            if self.common.login.logOutOfKMS() == False:
+                writeToLog("INFO","Step 7: FAILED to move to Anonymous user")
+                return
+                          
+            writeToLog("INFO","Step 8: Going to verify that for the " + self.anonymousUser + ", the " + self.channelName + " channel is displayed in global search")
+            if self.common.globalSearch.serchAndVerifyChannelInGlobalSearch(self.channelName) == False:
+                writeToLog("INFO","Step 8: FAILED, the "+ self.channelName + " channel hasn't been displayed in the global search results while it should")
+                return
+             
+            writeToLog("INFO","Step 9: Going to verify that for the " + self.anonymousUser + " , the " + self.entryName + " entry is  displayed in global search")
+            if self.common.globalSearch.serchAndVerifyEntryInGlobalSearch(self.entryName) == False:
+                writeToLog("INFO","Step 9: FAILED, the "+ self.entryName + " entry hasn't been displayed in the global search results while it should")
+                return 
+             
+            writeToLog("INFO","Step 10: Going to authenticate with , " + self.normalUser + " normal KMS user")
+            if self.common.login.loginToKMS(self.normalUser, self.userPassword) == False:
+                writeToLog("INFO","Step 10: FAILED to authenticate with , " + self.normalUser + " normal KMS user")
+                return
+             
+            writeToLog("INFO","Step 11: Going to verify that for the " + self.normalUser + ", the " + self.channelName + " channel is displayed in global search")
+            if self.common.globalSearch.serchAndVerifyChannelInGlobalSearch(self.channelName) == False:
+                writeToLog("INFO","Step 11: FAILED, the "+ self.channelName + " channel hasn't been found in in the global search results while it should")
+                return
+             
+            writeToLog("INFO","Step 12: Going to verify that for the " + self.normalUser + " , the " + self.entryName + " entry is displayed in global search")
+            if self.common.globalSearch.serchAndVerifyEntryInGlobalSearch(self.entryName) == False:
+                writeToLog("INFO","Step 12: FAILED, the " + self.entryName + " entry hasn't been found displayed in in the global search results while it should")
+                return 
+            
+            writeToLog("INFO","Step 13: Going to log out from " + self.normalUser + " and authenticate with " + self.memberUser)
+            if self.common.login.logOutThenLogInToKMS(self.memberUser, self.userPassword) == False:
+                writeToLog("INFO","Step 13: FAILED to log out from " + self.normalUser + " and authenticate with " + self.memberUser)
+                return
+            
+            writeToLog("INFO","Step 14: Going to verify that for the " + self.memberUser + ", the " + self.channelName + " channel is displayed in global search")
+            if self.common.globalSearch.serchAndVerifyChannelInGlobalSearch(self.channelName) == False:
+                writeToLog("INFO","Step 14: FAILED, the " + self.channelName + " channel hasn't been found in in the global search results while it should")
+                return
+             
+            writeToLog("INFO","Step 15: Going to verify that for the " + self.memberUser + " , the " + self.entryName + " entry is displayed in global search")
+            if self.common.globalSearch.serchAndVerifyEntryInGlobalSearch(self.entryName) == False:
+                writeToLog("INFO","Step 15: FAILED, the " + self.entryName + " entry hasn't been found displayed in in the global search results while it should")
+                return 
+            
+            writeToLog("INFO","Step 16: Going to log out from " + self.memberUser + " and authenticate with " + self.contributorUser)
+            if self.common.login.logOutThenLogInToKMS(self.contributorUser, self.userPassword) == False:
+                writeToLog("INFO","Step 16: FAILED to log out from " + self.memberUser + " and authenticate with " + self.contributorUser)
+                return
+            
+            writeToLog("INFO","Step 17: Going to verify that for the " + self.contributorUser + ", the " + self.channelName + " channel is displayed in global search")
+            if self.common.globalSearch.serchAndVerifyChannelInGlobalSearch(self.channelName) == False:
+                writeToLog("INFO","Step 17: FAILED, the "+ self.channelName + " channel hasn't been found in in the global search results while it should")
+                return
+             
+            writeToLog("INFO","Step 18: Going to verify that for the " + self.contributorUser + " , the " + self.entryName + " entry is displayed in global search")
+            if self.common.globalSearch.serchAndVerifyEntryInGlobalSearch(self.entryName) == False:
+                writeToLog("INFO","Step 18: FAILED, the " + self.entryName + " entry hasn't been found displayed in in the global search results while it should")
+                return 
+            ##################################################################
+            self.status="Pass"
+            writeToLog("INFO","TEST PASSED: " + self.typeTest)
+        # if an exception happened we need to handle it and fail the test
+        except Exception as inst:
+            self.status = clsTestService.handleException(self,inst,self.startTime)
+    ########################### TEST TEARDOWN ###########################
+    def teardown_method(self,method):
+        try:
+            self.common.handleTestFail(self.status)
+            writeToLog("INFO","**************** Starting: teardown_method ****************")
+            self.common.login.logOutOfKMS()
+            self.common.login.loginToKMS(localSettings.LOCAL_SETTINGS_LOGIN_USERNAME, localSettings.LOCAL_SETTINGS_LOGIN_PASSWORD)
+            self.common.myMedia.deleteEntriesFromMyMedia(self.entryName)
+            self.common.channel.deleteChannel(self.channelName)
+            writeToLog("INFO","**************** Ended: teardown_method *******************")
+        except:
+            pass
+        clsTestService.basicTearDown(self)
+        #write to log we finished the test
+        logFinishedTest(self,self.startTime)
+        assert (self.status == "Pass")
+
+    pytest.main('test_' + testNum  + '.py --tb=line')

--- a/web/tests/entitlements/test_5036.py
+++ b/web/tests/entitlements/test_5036.py
@@ -1,0 +1,192 @@
+import time, pytest
+import sys,os
+sys.path.insert(1,os.path.abspath(os.path.join(os.path.dirname( __file__ ),'..','..','lib')))
+from clsCommon import Common
+import clsTestService
+from localSettings import *
+import localSettings
+from utilityTestFunc import *
+import enums
+import collections
+
+
+class Test:
+
+    #================================================================================================================================
+    #  @Author: Horia Cus
+    # Test Name : Entitlements - Public Channel using Global Page and Anonymous Users OFF
+    # Test description:
+    # 1. Create a Public Channel
+    # 2. Publish an entry inside the Public Channel
+    # 3. Add a member and a contributor to the Public channel
+    # 4. Verify that the Channel owner its able to find the channel inside the global page
+    # 5. Verify that the KMS User, Channel Member and Contributor are able to access the channel and entry from global page
+    # 6. Verify that the Anonymous User is unable to access the channel and entry from global page
+    #================================================================================================================================
+    testNum = "5036"
+
+    supported_platforms = clsTestService.updatePlatforms(testNum)
+
+    status = "Fail"
+    timeout_accured = "False"
+    driver = None
+    common = None
+    # Test variables
+
+    typeTest            = "Entitlements of a Public Channel with Owner, Anonymous, Members and Contributor users"
+    instanceURL         = None
+
+    anonymousUser       = "Anonymous User"
+    normalUser          = "python_normal"
+    memberUser          = "python_member"
+    contributorUser     = "python_contributor"
+    userPassword        = "Kaltura1!"
+    
+    description         = "Description"
+    tags                = "Tags,"
+    entryName           = None
+    entryDescription    = "Public Entry Description"
+    entryTags           = "public,"
+    
+    channelName         = None
+    channelDescription  = "Public Channel Description"
+    channelTags         = "public,"
+
+    # Variables used in order to create a video entry with Slides and Captions
+    filePathVideo = localSettings.LOCAL_SETTINGS_MEDIA_PATH + r'\videos\QR_30_sec_new.mp4'    
+    #run test as different instances on all the supported platforms
+    @pytest.fixture(scope='module',params=supported_platforms)
+    def driverFix(self,request):
+        return request.param
+
+    def test_01(self,driverFix,env):
+        #write to log we started the test
+        logStartTest(self,driverFix)
+        try:
+            ########################### TEST SETUP ###########################
+            #capture test start time
+            self.startTime = time.time()
+            #initialize all the basic vars and start playing
+            self,self.driver = clsTestService.initializeAndLoginAsUser(self, driverFix)
+            self.common = Common(self.driver)
+            # Variables used in order to proper create the Entry
+            self.entryName             = clsTestService.addGuidToString("Entitlements - Public Channel Anonymous OFF", self.testNum)
+            self.channelName           = clsTestService.addGuidToString("Public Channel Anonymous OFF", self.testNum)
+            self.instanceUrl = self.common.base.driver.current_url
+            self.common.admin.allowAnonymous(False)
+            self.common.base.navigate(self.instanceUrl)
+            ##################### TEST STEPS - MAIN FLOW #####################
+            writeToLog("INFO","Step 1: Going to create " + self.channelName + " channel as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+            if self.common.channel.createChannel(self.channelName, self.channelDescription, self.channelTags, enums.ChannelPrivacyType.PUBLIC, True, True, True) == False:
+                writeToLog("INFO","Step 1: FAILED to create " + self.channelName + " channel as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+                return
+              
+            writeToLog("INFO","Step 2: Going to add " + self.memberUser + " as member of " + self.channelName)
+            if self.common.channel.addMembersToChannel(self.channelName, self.memberUser, enums.ChannelMemberPermission.MEMBER) == False:
+                writeToLog("INFO","Step 2: FAILED to add " + self.memberUser + " as member of " + self.channelName)
+                return
+            
+            writeToLog("INFO","Step 3: Going to add " + self.contributorUser + " as member of " + self.channelName)
+            if self.common.channel.addMembersToChannel(self.channelName, self.contributorUser, enums.ChannelMemberPermission.CONTRIBUTOR) == False:
+                writeToLog("INFO","Step 3: FAILED to add " + self.contributorUser + " as member of " + self.channelName)
+                return
+                
+            writeToLog("INFO","Step 4: Going to upload " + self.entryName + " entry as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+            if self.common.upload.uploadEntry(self.filePathVideo, self.entryName, self.entryDescription, self.entryTags, disclaimer=False) == None:
+                writeToLog("INFO","Step 4: FAILED to upload " + self.entryName + " entry as " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME)
+                return
+        
+            writeToLog("INFO","Step 5: Going to publish the " + self.entryName + " to the " + self.channelName)
+            if self.common.myMedia.publishSingleEntry(self.entryName, "", self.channelName) == False:
+                writeToLog("INFO","Step 5: FAILED to publish the " + self.entryName + " to the " + self.channelName)
+                return
+                          
+            writeToLog("INFO","Step 6: Going to verify that for the " + localSettings.LOCAL_SETTINGS_LOGIN_USERNAME + ", the " + self.channelName + " channel is displayed in global search")
+            if self.common.globalSearch.serchAndVerifyChannelInGlobalSearch(self.channelName) == False:
+                writeToLog("INFO","Step 6: FAILED, the " + self.channelName + " channel hasn't been found in the global search results while it should")
+                return
+            
+            writeToLog("INFO","Step 7: Going to move to Anonymous user")
+            if self.common.login.logOutOfKMS(allowAnonymous=False) == False:
+                writeToLog("INFO","Step 7: FAILED to move to Anonymous user")
+                return
+            
+            writeToLog("INFO","Step 8: Going to verify that for the " + self.anonymousUser + ", the " + self.channelName + " channel is not displayed in global search")
+            if self.common.globalSearch.serchAndVerifyChannelInGlobalSearch(self.channelName) != False:
+                writeToLog("INFO","Step 8: FAILED, the "+ self.channelName + " channel has been displayed in the global search results while it shouldn't")
+                return
+             
+            writeToLog("INFO","Step 9: Going to verify that for the " + self.anonymousUser + " , the " + self.entryName + " entry is not displayed in global search")
+            if self.common.globalSearch.serchAndVerifyEntryInGlobalSearch(self.entryName) != False:
+                writeToLog("INFO","Step 9: FAILED, the "+ self.entryName + " entry has been displayed in the global search results while it shouldn't")
+                return  
+             
+            writeToLog("INFO","Step 10: Going to authenticate with , " + self.normalUser + " normal KMS user")
+            if self.common.login.loginToKMS(self.normalUser, self.userPassword) == False:
+                writeToLog("INFO","Step 10: FAILED to authenticate with , " + self.normalUser + " normal KMS user")
+                return
+             
+            writeToLog("INFO","Step 11: Going to verify that for the " + self.normalUser + ", the " + self.channelName + " channel is displayed in global search")
+            if self.common.globalSearch.serchAndVerifyChannelInGlobalSearch(self.channelName) == False:
+                writeToLog("INFO","Step 11: FAILED, the "+ self.channelName + " channel hasn't been found in in the global search results while it should")
+                return
+             
+            writeToLog("INFO","Step 12: Going to verify that for the " + self.normalUser + " , the " + self.entryName + " entry is displayed in global search")
+            if self.common.globalSearch.serchAndVerifyEntryInGlobalSearch(self.entryName) == False:
+                writeToLog("INFO","Step 12: FAILED, the " + self.entryName + " entry hasn't been found displayed in in the global search results while it should")
+                return 
+            
+            writeToLog("INFO","Step 13: Going to log out from " + self.normalUser + " and authenticate with " + self.memberUser)
+            if self.common.login.logOutThenLogInToKMS(self.memberUser, self.userPassword, allowAnonymous=False) == False:
+                writeToLog("INFO","Step 13: FAILED to log out from " + self.normalUser + " and authenticate with " + self.memberUser)
+                return
+            
+            writeToLog("INFO","Step 14: Going to verify that for the " + self.memberUser + ", the " + self.channelName + " channel is displayed in global search")
+            if self.common.globalSearch.serchAndVerifyChannelInGlobalSearch(self.channelName) == False:
+                writeToLog("INFO","Step 14: FAILED, the " + self.channelName + " channel hasn't been found in in the global search results while it should")
+                return
+             
+            writeToLog("INFO","Step 15: Going to verify that for the " + self.memberUser + " , the " + self.entryName + " entry is displayed in global search")
+            if self.common.globalSearch.serchAndVerifyEntryInGlobalSearch(self.entryName) == False:
+                writeToLog("INFO","Step 15: FAILED, the " + self.entryName + " entry hasn't been found displayed in in the global search results while it should")
+                return 
+            
+            writeToLog("INFO","Step 16: Going to log out from " + self.memberUser + " and authenticate with " + self.contributorUser)
+            if self.common.login.logOutThenLogInToKMS(self.contributorUser, self.userPassword, allowAnonymous=False) == False:
+                writeToLog("INFO","Step 16: FAILED to log out from " + self.memberUser + " and authenticate with " + self.contributorUser)
+                return
+            
+            writeToLog("INFO","Step 17: Going to verify that for the " + self.contributorUser + ", the " + self.channelName + " channel is displayed in global search")
+            if self.common.globalSearch.serchAndVerifyChannelInGlobalSearch(self.channelName) == False:
+                writeToLog("INFO","Step 17: FAILED, the "+ self.channelName + " channel hasn't been found in in the global search results while it should")
+                return
+             
+            writeToLog("INFO","Step 18: Going to verify that for the " + self.contributorUser + " , the " + self.entryName + " entry is displayed in global search")
+            if self.common.globalSearch.serchAndVerifyEntryInGlobalSearch(self.entryName) == False:
+                writeToLog("INFO","Step 18: FAILED, the " + self.entryName + " entry hasn't been found displayed in in the global search results while it should")
+                return 
+            ##################################################################
+            self.status="Pass"
+            writeToLog("INFO","TEST PASSED: " + self.typeTest)
+        # if an exception happened we need to handle it and fail the test
+        except Exception as inst:
+            self.status = clsTestService.handleException(self,inst,self.startTime)
+    ########################### TEST TEARDOWN ###########################
+    def teardown_method(self,method):
+        try:
+            self.common.handleTestFail(self.status)
+            writeToLog("INFO","**************** Starting: teardown_method ****************")
+            self.common.admin.allowAnonymous(True)
+            self.common.login.logOutOfKMS()
+            self.common.login.loginToKMS(localSettings.LOCAL_SETTINGS_LOGIN_USERNAME, localSettings.LOCAL_SETTINGS_LOGIN_PASSWORD)
+            self.common.myMedia.deleteEntriesFromMyMedia(self.entryName)
+            self.common.channel.deleteChannel(self.channelName)
+            writeToLog("INFO","**************** Ended: teardown_method *******************")
+        except:
+            pass
+        clsTestService.basicTearDown(self)
+        #write to log we finished the test
+        logFinishedTest(self,self.startTime)
+        assert (self.status == "Pass")
+
+    pytest.main('test_' + testNum  + '.py --tb=line')


### PR DESCRIPTION
#4984 Entitlements - Entry Private with Co Editor and Demoted Co Editor
#4999 Entitlements - Private Channel using Channels Page
#5009 Entitlements - Open Channel using Channels Page
#5010 Entitlements - Restricted Channel using Channels Page
#5011 Entitlements - Shared Repository Channel using Channels Page
#5012 Entitlements - Public Channel using Channels Page and Anonymous Users ON
#5013 Entitlements - Public Channel using Channels Page and Anonymous Users OFF
#5022 Entitlements - Entry Private with Initial Owner changed to Co Publisher
#5024 Entitlements - Private Channel using Global Page
#5025 Entitlements - Open Channel using Global Page
#5026 Entitlements - Restricted Channel using Global Page
#5027 Entitlements - Shared Repository Channel using Global Search
#5028 Entitlements - Public Channel using Global Page and Anonymous Users ON
#5036 Entitlements - Public Channel using Global Page and Anonymous Users OFF
Created a new function, allowAnonymous, in order to disable / enable anonymous from admin panel
Updated the navigateToEntryFromChannel function signature, in order to support navigateFrom
Updated navigateToChannels function, in order to verify that log in screen is not presented
Created a new function, logOutThenLogIn to KMS, in order to save code duplicate within the test cases